### PR TITLE
[MISC] Replace seqan3/core/platform -> sharg/platform.

### DIFF
--- a/include/sharg/detail/concept.hpp
+++ b/include/sharg/detail/concept.hpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <seqan3/std/type_traits>
 
-#include <seqan3/core/platform.hpp>
+#include <sharg/platform.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/terminal.hpp
+++ b/include/sharg/detail/terminal.hpp
@@ -23,7 +23,7 @@
 
 #include <cstdio>
 
-#include <seqan3/core/platform.hpp>
+#include <sharg/platform.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -14,6 +14,7 @@
 
 #include <sys/stat.h>
 
+#include <seqan3/std/charconv>
 #include <chrono>
 #include <fstream>
 #include <future>
@@ -25,7 +26,6 @@
 #include <sharg/detail/terminal.hpp>
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/detail/safe_filesystem_entry.hpp>
-#include <seqan3/std/charconv>
 #include <seqan3/version.hpp>
 
 namespace sharg::detail


### PR DESCRIPTION
Fixes one task of https://github.com/seqan/sharg-parser/issues/4