### PR TITLE
[DOC] License fixup

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -11,7 +11,7 @@
 # Source code license
 
 The contents of this repository/directory, in particular the library
-source code of SeqAn3, are licensed under the following terms:
+source code of Sharg, are licensed under the following terms:
 
 ```
 Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
@@ -62,6 +62,6 @@ This includes:
 # Submodules
 
 This repository/directory may contain other projects' content in the
-`submodules`-subfolder. We try to ensure that all dependencies are
+`lib`-subfolder. We try to ensure that all dependencies are
 permissively licensed (BSD/MIT/X11/ISC/Boost…), but please verify the
 respective license files yourself.

--- a/build_system/sharg-config-version.cmake
+++ b/build_system/sharg-config-version.cmake
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
-# shipped with this file and also available at: https://github.com/shargcpp/sharg/blob/master/LICENSE
-# -----------------------------------------------------------------------------------------------------
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------------
 
 # This file adds version support for `find_package(SHARG 3.1)`.
 # See https://cmake.org/cmake/help/v3.16/manual/cmake-packages.7.html#package-version-file for more information.

--- a/build_system/sharg-config.cmake
+++ b/build_system/sharg-config.cmake
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 #
 # This CMake module will try to find SHARG and its dependencies.  You can use
 # it the same way you would use any other CMake module.

--- a/include/sharg/all.hpp
+++ b/include/sharg/all.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/concept.hpp
+++ b/include/sharg/detail/concept.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/format_html.hpp
+++ b/include/sharg/detail/format_html.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/format_man.hpp
+++ b/include/sharg/detail/format_man.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/terminal.hpp
+++ b/include/sharg/detail/terminal.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/exceptions.hpp
+++ b/include/sharg/exceptions.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/platform.hpp
+++ b/include/sharg/platform.hpp
@@ -1,10 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
-// Copyright (c) 2020-2021, deCODE Genetics
+// -----------------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
-// shipped with this file and also available at: https://github.com/seqan/b.i.o./blob/master/LICENSE
-// -----------------------------------------------------------------------------------------------------
+// shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------------
 
 #pragma once
 

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 /*!\file
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/version.hpp
+++ b/include/sharg/version.hpp
@@ -1,10 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
-// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
-// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
-// Copyright (c) 2020-2021, deCODE Genetics
+// -----------------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
-// shipped with this file and also available at: https://github.com/seqan/b.i.o./blob/master/LICENSE
-// -----------------------------------------------------------------------------------------------------
+// shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------------
 
 #pragma once
 

--- a/test/documentation/CMakeLists.txt
+++ b/test/documentation/CMakeLists.txt
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 
 # Minimum cmake version
 cmake_minimum_required(VERSION 3.7)

--- a/test/documentation/doc_dev/CMakeLists.txt
+++ b/test/documentation/doc_dev/CMakeLists.txt
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 
 message (STATUS "Configuring devel doc.")
 

--- a/test/documentation/doc_usr/CMakeLists.txt
+++ b/test/documentation/doc_usr/CMakeLists.txt
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 
 message (STATUS "Configuring user doc.")
 

--- a/test/documentation/sharg-doxygen-package.cmake
+++ b/test/documentation/sharg-doxygen-package.cmake
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 
 cmake_minimum_required (VERSION 3.10)
 

--- a/test/documentation/sharg-doxygen.cmake
+++ b/test/documentation/sharg-doxygen.cmake
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 
 cmake_minimum_required (VERSION 3.10)
 

--- a/test/snippet/CMakeLists.txt
+++ b/test/snippet/CMakeLists.txt
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 
 cmake_minimum_required (VERSION 3.10)
 project (sharg_test_snippet CXX)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 
 cmake_minimum_required (VERSION 3.10)
 project (sharg_test_unit CXX)

--- a/test/unit/argument_parser_design_error_test.cpp
+++ b/test/unit/argument_parser_design_error_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
 

--- a/test/unit/coverage/CMakeLists.txt
+++ b/test/unit/coverage/CMakeLists.txt
@@ -1,9 +1,9 @@
-# -----------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------------------------------------
 # Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 # Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 # This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
-# shipped with this file and also available at: https://github.com/seqan/raptor/blob/master/LICENSE.md
-# -----------------------------------------------------------------------------------------------------
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------------
 
 cmake_minimum_required (VERSION 3.10)
 

--- a/test/unit/detail/CMakeLists.txt
+++ b/test/unit/detail/CMakeLists.txt
@@ -1,3 +1,10 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------------
+
 find_path (SEQAN3_TEST_LICENSE_DIR NAMES LICENSE.md HINTS "${SEQAN3_CLONE_DIR}")
 
 add_definitions(-DSEQAN3_TEST_LICENSE_DIR="${SEQAN3_TEST_LICENSE_DIR}")

--- a/test/unit/detail/format_help_test.cpp
+++ b/test/unit/detail/format_help_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #include <fstream>
 #include <seqan3/std/ranges>

--- a/test/unit/detail/format_html_test.cpp
+++ b/test/unit/detail/format_html_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
 

--- a/test/unit/detail/format_man_test.cpp
+++ b/test/unit/detail/format_man_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #include <string>
 #include <vector>

--- a/test/unit/detail/version_check_debug_test.cpp
+++ b/test/unit/detail/version_check_debug_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #if defined(NDEBUG)
     #undef NDEBUG // test in debug mode

--- a/test/unit/detail/version_check_release_test.cpp
+++ b/test/unit/detail/version_check_release_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #if !defined(NDEBUG)
     #define NDEBUG // test in release mode

--- a/test/unit/detail/version_check_test.hpp
+++ b/test/unit/detail/version_check_test.hpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
 

--- a/test/unit/format_parse_test.cpp
+++ b/test/unit/format_parse_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
 

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -1,9 +1,9 @@
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 // Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 // Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
 // This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
-// -----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------------
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Related to #20 

This changes the library name `SeqAn3->Sharg` and submodule name `submodules->lib` in the `LICENSE.md`.

It also makes sure that all files use the same license text.