### PR TITLE
[MISC] header

### DIFF
--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -42,6 +42,33 @@ jobs:
             skip_build_tests: false
             skip_run_tests: false
 
+          - name: "Header gcc11"
+            cxx: "g++-11"
+            cc: "gcc-11"
+            build: header
+            build_type: Debug
+            build_threads: 2
+            test_threads: 2
+            cmake: 3.10.3
+            requires_toolchain: true
+            requires_ccache: true
+            skip_build_tests: false
+            skip_run_tests: false
+
+          - name: "Header gcc9"
+            cxx: "g++-9"
+            cc: "gcc-9"
+            build: header
+            build_type: Debug
+            build_threads: 2
+            test_threads: 2
+            cxx_flags: "-std=c++2a"
+            cmake: 3.10.3
+            requires_toolchain: true
+            requires_ccache: true
+            skip_build_tests: false
+            skip_run_tests: false
+
           - name: "Documentation"
             build: documentation
             build_threads: 2
@@ -127,6 +154,7 @@ jobs:
                                                   -DSHARG_VERBOSE_TESTS=OFF
           case "${{ matrix.build }}" in
             snippet) make -j${{ matrix.build_threads }} gtest_build;;
+            header) make -j${{ matrix.build_threads }} gtest_build gbenchmark_build;;
             documentation) make -j${{ matrix.build_threads }} download-cppreference-doxygen-web-tag;;
           esac
 

--- a/doc/cookbook/basic_arg_parse.cpp
+++ b/doc/cookbook/basic_arg_parse.cpp
@@ -1,11 +1,10 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 void run_program(std::filesystem::path const & reference_path,
                  std::filesystem::path const & index_path)
 {
-    seqan3::debug_stream << "reference_file_path: " << reference_path << '\n';
-    seqan3::debug_stream << "index_path           " << index_path << '\n';
+    std::cerr << "reference_file_path: " << reference_path << '\n';
+    std::cerr << "index_path           " << index_path << '\n';
 }
 
 struct cmd_arguments

--- a/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
+++ b/doc/howto/subcommand_argument_parser/subcommand_arg_parse.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 // =====================================================================================================================
 // pull
@@ -25,11 +24,11 @@ int run_git_pull(sharg::argument_parser & parser)
     }
     catch (sharg::argument_parser_error const & ext)
     {
-        seqan3::debug_stream << "[Error git pull] " << ext.what() << "\n";
+        std::cerr << "[Error git pull] " << ext.what() << "\n";
         return -1;
     }
 
-    seqan3::debug_stream << "Git pull with repository " << args.repository << " and branch " << args.branch << '\n';
+    std::cerr << "Git pull with repository " << args.repository << " and branch " << args.branch << '\n';
 
     return 0;
 }
@@ -58,11 +57,14 @@ int run_git_push(sharg::argument_parser & parser)
     }
     catch (sharg::argument_parser_error const & ext)
     {
-        seqan3::debug_stream << "[Error git push] " << ext.what() << "\n";
+        std::cerr << "[Error git push] " << ext.what() << "\n";
         return -1;
     }
 
-    seqan3::debug_stream << "Git push with repository " << args.repository << " and branches " << args.branches << '\n';
+    std::cerr << "Git push with repository " << args.repository << " and branches ";
+    for (auto && branch : args.branches)
+        std::cerr << branch << ' ';
+    std::cerr << '\n';
 
     return 0;
 }
@@ -93,7 +95,7 @@ int main(int argc, char const ** argv)
     }
     catch (sharg::argument_parser_error const & ext) // catch user errors
     {
-        seqan3::debug_stream << "[Error] " << ext.what() << "\n"; // customise your error message
+        std::cerr << "[Error] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/basic_parser_setup.cpp
+++ b/doc/tutorial/argument_parser/basic_parser_setup.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>   // includes all necessary headers
-#include <seqan3/core/debug_stream.hpp>     // our custom output stream
 
 int main(int argc, char ** argv)
 {
@@ -13,7 +12,7 @@ int main(int argc, char ** argv)
     }
     catch (sharg::argument_parser_error const & ext)                     // catch user errors
     {
-        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        std::cerr << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 }

--- a/doc/tutorial/argument_parser/small_snippets.cpp
+++ b/doc/tutorial/argument_parser/small_snippets.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <filesystem>
 
 //![validator_include]
 #include <sharg/validators.hpp>

--- a/doc/tutorial/argument_parser/solution1.cpp
+++ b/doc/tutorial/argument_parser/solution1.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp> // includes all necessary headers
-#include <seqan3/core/debug_stream.hpp>   // our custom output stream
 
 void initialise_argument_parser(sharg::argument_parser & parser)
 {

--- a/doc/tutorial/argument_parser/solution3.cpp
+++ b/doc/tutorial/argument_parser/solution3.cpp
@@ -1,11 +1,5 @@
 //![program]
-#include <seqan3/std/charconv>            // includes std::from_chars
-#include <filesystem>                     // use std::filesystem::path
-#include <fstream>
-#include <numeric>
-
 #include <sharg/all.hpp> // includes all necessary headers
-#include <seqan3/core/debug_stream.hpp>   // our custom output stream
 
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
@@ -20,7 +14,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        std::cerr << "Could not cast '" << str << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -48,16 +42,16 @@ void run_program(std::filesystem::path & path, uint32_t yr, std::string & aggr_b
         }
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
+            std::cerr << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
-            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+            std::cerr << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
                                  << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
+            std::cerr << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {
-        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
+        std::cerr << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -102,7 +96,7 @@ int main(int argc, char ** argv)
     }
     catch (sharg::argument_parser_error const & ext)                     // catch user errors
     {
-        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        std::cerr << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/solution4.cpp
+++ b/doc/tutorial/argument_parser/solution4.cpp
@@ -1,10 +1,4 @@
-#include <fstream>
-#include <numeric>
-
 #include <sharg/all.hpp> // includes all necessary headers
-#include <seqan3/core/debug_stream.hpp>   // our custom output stream
-#include <seqan3/std/charconv>            // includes std::from_chars
-#include <filesystem>                     // use std::filesystem::path
 
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
@@ -19,7 +13,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        std::cerr << "Could not cast '" << str << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -49,16 +43,16 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         //![altered_while]
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
+            std::cerr << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
-            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+            std::cerr << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
                                  << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
+            std::cerr << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {
-        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
+        std::cerr << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -102,7 +96,7 @@ int main(int argc, char ** argv)
     }
     catch (sharg::argument_parser_error const & ext)                     // catch user errors
     {
-        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        std::cerr << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -1,10 +1,4 @@
-#include <fstream>
-#include <numeric>
-
 #include <sharg/all.hpp> // includes all necessary headers
-#include <seqan3/core/debug_stream.hpp>   // our custom output stream
-#include <seqan3/std/charconv>            // includes std::from_chars
-#include <filesystem>                     // use std::filesystem::path
 
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
@@ -19,7 +13,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        std::cerr << "Could not cast '" << str << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -47,16 +41,16 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         }
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
+            std::cerr << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
-            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+            std::cerr << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
                                  << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
+            std::cerr << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {
-        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
+        std::cerr << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -100,7 +94,7 @@ int main(int argc, char ** argv)
     }
     catch (sharg::argument_parser_error const & ext)                     // catch user errors
     {
-        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        std::cerr << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -1,10 +1,4 @@
-#include <fstream>
-#include <numeric>
-
 #include <sharg/all.hpp> // includes all necessary headers
-#include <seqan3/core/debug_stream.hpp>   // our custom output stream
-#include <seqan3/std/charconv>            // includes std::from_chars
-#include <filesystem>                     // use std::filesystem::path
 
 // This is the program!
 // Take a look at it if you are interested in an example of parsing a data file.
@@ -19,7 +13,7 @@ number_type to_number(range_type && range)
 
     if (res.ec != std::errc{})
     {
-        seqan3::debug_stream << "Could not cast '" << range << "' to a valid number\n";
+        std::cerr << "Could not cast '" << str << "' to a valid number\n";
         throw std::invalid_argument{"CAST ERROR"};
     }
     return num;
@@ -47,16 +41,16 @@ void run_program(std::filesystem::path & path, std::vector<uint8_t> sn, std::str
         }
 
         if (aggr_by == "median")
-            seqan3::debug_stream << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
+            std::cerr << ([&v] () { std::sort(v.begin(), v.end()); return v[v.size()/2]; })() << '\n';
         else if (aggr_by == "mean")
-            seqan3::debug_stream << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
+            std::cerr << ([&v] () { double sum{}; for (auto i : v) sum += i; return sum / v.size(); })()
                                  << '\n';
         else
-            seqan3::debug_stream << "I do not know the aggregation method " << aggr_by << '\n';
+            std::cerr << "I do not know the aggregation method " << aggr_by << '\n';
     }
     else
     {
-        seqan3::debug_stream << "Error: Cannot open file for reading.\n";
+        std::cerr << "Error: Cannot open file for reading.\n";
     }
 }
 // -----------------------------------------------------------------------------
@@ -107,7 +101,7 @@ int main(int argc, char ** argv)
     }
     catch (sharg::argument_parser_error const & ext)                     // catch user errors
     {
-        seqan3::debug_stream << "[Winter has come] " << ext.what() << "\n"; // customise your error message
+        std::cerr << "[Winter has come] " << ext.what() << "\n"; // customise your error message
         return -1;
     }
 

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -21,15 +21,15 @@
 #include <vector>
 #include <regex>
 
-// #include <sharg/detail/format_ctd.hpp>
+#include <seqan3/core/debug_stream/detail/to_string.hpp>
+#include <seqan3/core/detail/test_accessor.hpp>
+
 #include <sharg/detail/format_help.hpp>
 #include <sharg/detail/format_html.hpp>
 #include <sharg/detail/format_man.hpp>
 #include <sharg/detail/format_parse.hpp>
 #include <sharg/detail/terminal.hpp>
 #include <sharg/detail/version_check.hpp>
-#include <seqan3/core/debug_stream/detail/to_string.hpp>
-#include <seqan3/core/detail/test_accessor.hpp>
 
 namespace sharg
 {

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -15,7 +15,6 @@
 #include <set>
 
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
-#include <seqan3/core/detail/test_accessor.hpp>
 
 #include <sharg/detail/format_help.hpp>
 #include <sharg/detail/format_html.hpp>

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -20,7 +20,6 @@
 #include <sharg/detail/format_html.hpp>
 #include <sharg/detail/format_man.hpp>
 #include <sharg/detail/format_parse.hpp>
-#include <sharg/detail/terminal.hpp>
 #include <sharg/detail/version_check.hpp>
 
 namespace sharg

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -12,14 +12,7 @@
 
 #pragma once
 
-#include <future>
-#include <iostream>
 #include <set>
-#include <sstream>
-#include <string>
-#include <variant>
-#include <vector>
-#include <regex>
 
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/detail/test_accessor.hpp>

--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -22,6 +22,8 @@
 #include <seqan3/std/concepts>
 #include <seqan3/std/type_traits>
 
+#include <sharg/platform.hpp>
+
 namespace sharg::custom
 {
 

--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -18,8 +18,6 @@
 #include <seqan3/core/debug_stream/debug_stream_type.hpp>
 #include <seqan3/core/detail/customisation_point.hpp>
 #include <seqan3/io/stream/concept.hpp>
-#include <seqan3/std/concepts>
-#include <seqan3/std/type_traits>
 
 #include <sharg/platform.hpp>
 

--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -12,15 +12,15 @@
 
 #pragma once
 
-#include <seqan3/std/concepts>
 #include <sstream>
-#include <seqan3/std/type_traits>
 #include <unordered_map>
 #include <vector>
 
 #include <seqan3/core/debug_stream/debug_stream_type.hpp>
 #include <seqan3/core/detail/customisation_point.hpp>
 #include <seqan3/io/stream/concept.hpp>
+#include <seqan3/std/concepts>
+#include <seqan3/std/type_traits>
 
 namespace sharg::custom
 {

--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <sstream>
 #include <unordered_map>
 #include <vector>
 

--- a/include/sharg/detail/concept.hpp
+++ b/include/sharg/detail/concept.hpp
@@ -14,9 +14,6 @@
 
 #include <string>
 
-#include <seqan3/std/concepts>
-#include <seqan3/std/type_traits>
-
 #include <sharg/platform.hpp>
 
 namespace sharg::detail

--- a/include/sharg/detail/concept.hpp
+++ b/include/sharg/detail/concept.hpp
@@ -12,8 +12,9 @@
 
 #pragma once
 
-#include <seqan3/std/concepts>
 #include <string>
+
+#include <seqan3/std/concepts>
 #include <seqan3/std/type_traits>
 
 #include <sharg/platform.hpp>

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <seqan3/utility/detail/type_name_as_string.hpp>
+#include <seqan3/utility/type_list/traits.hpp>
 
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/concept.hpp>

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -24,7 +24,7 @@
 #include <sharg/exceptions.hpp>
 #include <sharg/validators.hpp>
 #include <seqan3/utility/detail/type_name_as_string.hpp>
-#include <seqan3/version.hpp>
+#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -13,12 +13,6 @@
 
 #pragma once
 
-#include <filesystem>
-#include <iostream>
-#include <limits>
-#include <sstream>
-#include <string>
-
 #include <seqan3/utility/detail/type_name_as_string.hpp>
 
 #include <sharg/auxiliary.hpp>

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -18,9 +18,7 @@
 
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/concept.hpp>
-#include <sharg/exceptions.hpp>
 #include <sharg/validators.hpp>
-#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -19,11 +19,12 @@
 #include <sstream>
 #include <string>
 
+#include <seqan3/utility/detail/type_name_as_string.hpp>
+
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/concept.hpp>
 #include <sharg/exceptions.hpp>
 #include <sharg/validators.hpp>
-#include <seqan3/utility/detail/type_name_as_string.hpp>
 #include <sharg/version.hpp>
 
 namespace sharg::detail

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -14,10 +14,15 @@
 
 #pragma once
 
-#include <seqan3/core/detail/test_accessor.hpp>
-
 #include <sharg/detail/format_base.hpp>
 #include <sharg/detail/terminal.hpp>
+
+namespace seqan3::detail
+{
+
+struct test_accessor;
+
+} // seqan3::detail
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -17,9 +17,10 @@
 #include <cassert>
 #include <iostream>
 
+#include <seqan3/core/detail/test_accessor.hpp>
+
 #include <sharg/detail/format_base.hpp>
 #include <sharg/detail/terminal.hpp>
-#include <seqan3/core/detail/test_accessor.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -14,9 +14,6 @@
 
 #pragma once
 
-#include <cassert>
-#include <iostream>
-
 #include <seqan3/core/detail/test_accessor.hpp>
 
 #include <sharg/detail/format_base.hpp>

--- a/include/sharg/detail/format_html.hpp
+++ b/include/sharg/detail/format_html.hpp
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include <sharg/detail/format_base.hpp>
 #include <sharg/detail/terminal.hpp>
 #include <sharg/version.hpp>

--- a/include/sharg/detail/format_html.hpp
+++ b/include/sharg/detail/format_html.hpp
@@ -13,8 +13,6 @@
 #pragma once
 
 #include <sharg/detail/format_base.hpp>
-#include <sharg/detail/terminal.hpp>
-#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_html.hpp
+++ b/include/sharg/detail/format_html.hpp
@@ -16,7 +16,7 @@
 
 #include <sharg/detail/format_base.hpp>
 #include <sharg/detail/terminal.hpp>
-#include <seqan3/version.hpp>
+#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_man.hpp
+++ b/include/sharg/detail/format_man.hpp
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#include <iostream>
-
 #include <sharg/detail/format_base.hpp>
 #include <sharg/detail/terminal.hpp>
 #include <sharg/version.hpp>

--- a/include/sharg/detail/format_man.hpp
+++ b/include/sharg/detail/format_man.hpp
@@ -13,8 +13,6 @@
 #pragma once
 
 #include <sharg/detail/format_base.hpp>
-#include <sharg/detail/terminal.hpp>
-#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_man.hpp
+++ b/include/sharg/detail/format_man.hpp
@@ -16,7 +16,7 @@
 
 #include <sharg/detail/format_base.hpp>
 #include <sharg/detail/terminal.hpp>
-#include <seqan3/version.hpp>
+#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <seqan3/std/charconv>
-#include <seqan3/std/concepts>
 #include <seqan3/utility/char_operations/predicate.hpp>
 
 #include <sharg/detail/format_base.hpp>

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -12,14 +12,15 @@
 
 #pragma once
 
-#include <seqan3/std/charconv>
-#include <seqan3/std/concepts>
 #include <sstream>
 #include <string>
 #include <vector>
 
-#include <sharg/detail/format_base.hpp>
+#include <seqan3/std/charconv>
+#include <seqan3/std/concepts>
 #include <seqan3/utility/char_operations/predicate.hpp>
+
+#include <sharg/detail/format_base.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -12,10 +12,6 @@
 
 #pragma once
 
-#include <sstream>
-#include <string>
-#include <vector>
-
 #include <seqan3/std/charconv>
 #include <seqan3/std/concepts>
 #include <seqan3/utility/char_operations/predicate.hpp>

--- a/include/sharg/detail/terminal.hpp
+++ b/include/sharg/detail/terminal.hpp
@@ -73,4 +73,4 @@ inline unsigned get_terminal_width()
 #endif
 }
 
-}  // namespace seqan::detail
+}  // namespace sharg::detail

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -25,7 +25,7 @@
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/terminal.hpp>
 #include <seqan3/io/detail/safe_filesystem_entry.hpp>
-#include <seqan3/version.hpp>
+#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -23,7 +23,6 @@
 
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/terminal.hpp>
-#include <sharg/version.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -12,9 +12,6 @@
 
 #pragma once
 
-#include <sys/stat.h>
-
-#include <chrono>
 #include <fstream>
 #include <future>
 #include <iostream>

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -14,7 +14,6 @@
 
 #include <sys/stat.h>
 
-#include <seqan3/std/charconv>
 #include <chrono>
 #include <fstream>
 #include <future>
@@ -22,9 +21,11 @@
 #include <optional>
 #include <regex>
 
+#include <seqan3/io/detail/safe_filesystem_entry.hpp>
+#include <seqan3/std/charconv>
+
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/terminal.hpp>
-#include <seqan3/io/detail/safe_filesystem_entry.hpp>
 #include <sharg/version.hpp>
 
 namespace sharg::detail

--- a/include/sharg/platform.hpp
+++ b/include/sharg/platform.hpp
@@ -7,10 +7,6 @@
 
 #pragma once
 
-#include <cinttypes>
-#include <ciso646> // makes _LIBCPP_VERSION available
-#include <cstddef> // makes __GLIBCXX__ available
-
 /*!\file
  * \brief Provides platform and dependency checks.
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -12,21 +12,22 @@
 
 #pragma once
 
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
 #include <filesystem>
 #include <fstream>
-#include <seqan3/std/ranges>
 #include <regex>
 #include <sstream>
 
-#include <sharg/exceptions.hpp>
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/debug_stream/range.hpp>
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/detail/safe_filesystem_entry.hpp>
+#include <seqan3/std/algorithm>
+#include <seqan3/std/concepts>
+#include <seqan3/std/ranges>
 #include <seqan3/utility/type_list/traits.hpp>
 #include <seqan3/utility/views/join_with.hpp>
+
+#include <sharg/exceptions.hpp>
 
 namespace sharg
 {

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -12,10 +12,8 @@
 
 #pragma once
 
-#include <filesystem>
 #include <fstream>
 #include <regex>
-#include <sstream>
 
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/debug_stream/range.hpp>

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -19,10 +19,6 @@
 #include <seqan3/core/debug_stream/range.hpp>
 #include <seqan3/io/detail/misc.hpp>
 #include <seqan3/io/detail/safe_filesystem_entry.hpp>
-#include <seqan3/std/algorithm>
-#include <seqan3/std/concepts>
-#include <seqan3/std/ranges>
-#include <seqan3/utility/type_list/traits.hpp>
 #include <seqan3/utility/views/join_with.hpp>
 
 #include <sharg/exceptions.hpp>

--- a/include/sharg/version.hpp
+++ b/include/sharg/version.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 
 /*!\file

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -1,0 +1,84 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+# -----------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.10)
+project (sharg_header_test CXX)
+
+find_package (SHARG REQUIRED HINTS ${CMAKE_CURRENT_LIST_DIR}/../../build_system)
+
+include (${CMAKE_CURRENT_LIST_DIR}/../../lib/seqan3/test/seqan3-test.cmake)
+
+macro (sharg_header_test component header_base_path exclude_regex)
+    set (target "${component}_header_test")
+
+    seqan3_test_files (header_files "${header_base_path}" "*.hpp;*.h")
+
+    if (NOT ";${exclude_regex};" STREQUAL ";;")
+        list (FILTER header_files EXCLUDE REGEX "${exclude_regex}")
+    endif()
+
+    file (WRITE "${PROJECT_BINARY_DIR}/${target}.cpp" "")
+    add_executable (${target} ${PROJECT_BINARY_DIR}/${target}.cpp)
+    target_link_libraries (${target} seqan3::test::header sharg::sharg)
+    add_test (NAME "header/${target}" COMMAND ${target})
+
+    foreach (header ${header_files})
+        seqan3_test_component (header_test_name "${header}" TEST_NAME)
+        seqan3_test_component (header_target_name "${header}" TARGET_UNIQUE_NAME)
+
+        foreach (header_sub_test "header-guard" "no-self-include")
+            set (header_target_source "${PROJECT_BINARY_DIR}/${target}_files/${header_test_name}.hpp-${header_sub_test}.cpp")
+            set (header_target "${target}--${header_target_name}-${header_sub_test}")
+
+            string (REPLACE "-" "__" header_test_name_safe "${target}, ${header_target}")
+
+            add_custom_command (OUTPUT "${header_target_source}"
+                                COMMAND "${CMAKE_COMMAND}"
+                                        "-DHEADER_FILE_ABSOLUTE=${header_base_path}/${header}"
+                                        "-DHEADER_FILE_INCLUDE=${header}"
+                                        "-DHEADER_TARGET_SOURCE=${header_target_source}"
+                                        "-DHEADER_TEST_NAME_SAFE=${header_test_name_safe}"
+                                        "-DHEADER_COMPONENT=${component}"
+                                        "-DHEADER_SUB_TEST=${header_sub_test}"
+                                        "-P"
+                                        "${CMAKE_CURRENT_SOURCE_DIR}/generate_header_source.cmake"
+                                DEPENDS "${header_base_path}/${header}"
+                                        "${CMAKE_CURRENT_SOURCE_DIR}/generate_header_source.cmake")
+            add_library (${header_target} OBJECT "${header_target_source}")
+
+            if (CMAKE_VERSION VERSION_LESS 3.12)
+                target_compile_options (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_COMPILE_OPTIONS>)
+                target_compile_definitions (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_COMPILE_DEFINITIONS>)
+                target_include_directories (${header_target} PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_INCLUDE_DIRECTORIES>)
+                target_include_directories (${header_target} SYSTEM PRIVATE $<TARGET_PROPERTY:seqan3::test::header,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
+                target_compile_options (${header_target} PRIVATE $<TARGET_PROPERTY:sharg::sharg,INTERFACE_COMPILE_OPTIONS>)
+                target_compile_definitions (${header_target} PRIVATE $<TARGET_PROPERTY:sharg::sharg,INTERFACE_COMPILE_DEFINITIONS>)
+                target_include_directories (${header_target} PRIVATE $<TARGET_PROPERTY:sharg::sharg,INTERFACE_INCLUDE_DIRECTORIES>)
+                target_include_directories (${header_target} SYSTEM PRIVATE $<TARGET_PROPERTY:sharg::sharg,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
+                add_dependencies (${header_target} gtest gbenchmark)
+            else ()
+                target_link_libraries (${header_target} seqan3::test::header sharg::sharg)
+            endif ()
+
+            target_sources (${target} PRIVATE $<TARGET_OBJECTS:${header_target}>)
+        endforeach ()
+    endforeach ()
+
+    unset (target)
+    unset (header_files)
+    unset (header_test_name)
+    unset (header_test_name_safe)
+    unset (header_target_name)
+    unset (header_target_source)
+    unset (header_target)
+endmacro ()
+
+seqan3_require_ccache ()
+seqan3_require_benchmark ()
+seqan3_require_test ()
+
+sharg_header_test (sharg "${SHARG_INCLUDE_DIR}" "")

--- a/test/header/generate_header_source.cmake
+++ b/test/header/generate_header_source.cmake
@@ -1,0 +1,65 @@
+cmake_minimum_required (VERSION 3.10)
+
+option (HEADER_FILE_ABSOLUTE "")
+option (HEADER_FILE_INCLUDE "")
+option (HEADER_TARGET_SOURCE "")
+option (HEADER_TEST_NAME_SAFE "")
+option (HEADER_COMPONENT "")
+option (HEADER_SUB_TEST "")
+
+file (WRITE "${HEADER_TARGET_SOURCE}" "") # write empty file
+
+if (HEADER_SUB_TEST STREQUAL "no-self-include")
+    # this test ensures that a header will not be included by itself later
+    file (READ "${HEADER_FILE_ABSOLUTE}" header_content)
+
+    string (REPLACE "#pragma once" "" header_content "${header_content}")
+
+    file (APPEND "${HEADER_TARGET_SOURCE}" "${header_content}")
+else ()
+    # this test ensures that a header guard is in place
+    file (APPEND "${HEADER_TARGET_SOURCE}" "
+#include <${HEADER_FILE_INCLUDE}>
+#include <${HEADER_FILE_INCLUDE}>")
+endif()
+
+# these includes are required by some headers (note that they follow)
+file (APPEND "${HEADER_TARGET_SOURCE}" "
+#include <gtest/gtest.h>
+#include <benchmark/benchmark.h>
+TEST(${HEADER_TEST_NAME_SAFE}) {}")
+
+# test that sharg headers include platform.hpp
+if ("${HEADER_COMPONENT}" MATCHES "sharg")
+
+    # exclude sharg/std/*, sharg/contrib/*, and sharg/version.hpp from platform test
+    if (NOT HEADER_FILE_INCLUDE MATCHES "sharg/(std/|contrib/|version.hpp)")
+        file (APPEND "${HEADER_TARGET_SOURCE}" "
+#ifndef SHARG_DOXYGEN_ONLY
+#error \"Your header '${HEADER_FILE_INCLUDE}' file is missing #include <sharg/platform.hpp>\"
+#endif")
+    endif ()
+
+    # sharg/std/* must not include platform.hpp (and therefore any other sharg header)
+    # See https://github.com/seqan/product_backlog/issues/135
+    if (HEADER_FILE_INCLUDE MATCHES "sharg/std/")
+        file (APPEND "${HEADER_TARGET_SOURCE}" "
+#ifdef SHARG_DOXYGEN_ONLY
+#error \"The standard header '${HEADER_FILE_INCLUDE}' file MUST NOT include any other sharg header (except for sharg/contrib)\"
+#endif")
+    endif ()
+
+    # test whether sharg has the visibility bug on lower gcc versions
+    # https://github.com/seqan/seqan3/issues/1317
+    if (NOT HEADER_FILE_INCLUDE MATCHES "sharg/version.hpp")
+        file (APPEND "${HEADER_TARGET_SOURCE}" "
+#include <sharg/platform.hpp>
+class A{ int i{5}; };
+
+template <typename t>
+concept private_bug = requires(t a){a.i;};
+
+static_assert(!private_bug<A>, \"See https://github.com/seqan/seqan3/issues/1317\");")
+    endif ()
+
+endif ()

--- a/test/snippet/argument_parser_1.cpp
+++ b/test/snippet/argument_parser_1.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 int main(int argc, char ** argv)
 {
@@ -32,7 +31,7 @@ int main(int argc, char ** argv)
 
     avg = avg / grades.size();
 
-    seqan3::debug_stream << name << " has an average grade of " << avg << '\n';
+    std::cerr << name << " has an average grade of " << avg << '\n';
 
     return 0;
 }

--- a/test/snippet/argument_parser_2.cpp
+++ b/test/snippet/argument_parser_2.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 int main(int argc, char ** argv)
 {
@@ -19,6 +18,6 @@ int main(int argc, char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "integer given by user: " << age << '\n';
+    std::cerr << "integer given by user: " << age << '\n';
     return 0;
 }

--- a/test/snippet/custom_argument_parsing_enumeration.cpp
+++ b/test/snippet/custom_argument_parsing_enumeration.cpp
@@ -1,7 +1,6 @@
 #include <system_error>
 
 #include <sharg/all.hpp>
-#include <seqan3/std/ranges>
 
 namespace sharg::custom
 {

--- a/test/snippet/is_option_set.cpp
+++ b/test/snippet/is_option_set.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 int main(int argc, char ** argv)
 {
@@ -19,10 +18,10 @@ int main(int argc, char ** argv)
     }
 
     if (myparser.is_option_set('a'))
-        seqan3::debug_stream << "The user set option -a on the command line.\n";
+        std::cerr << "The user set option -a on the command line.\n";
 
     if (myparser.is_option_set("awesome-parameter"))
-        seqan3::debug_stream << "The user set option --awesome-parameter on the command line.\n";
+        std::cerr << "The user set option --awesome-parameter on the command line.\n";
 
     // Asking for an option identifier that was not used before throws an error:
     // myparser.is_option_set("foo"); // throws sharg::design_error

--- a/test/snippet/validators_1.cpp
+++ b/test/snippet/validators_1.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 int main(int argc, const char ** argv)
 {
@@ -25,6 +24,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "integer given by user passed validation: " << myint << "\n";
+    std::cerr << "integer given by user passed validation: " << myint << "\n";
     return 0;
 }

--- a/test/snippet/validators_2.cpp
+++ b/test/snippet/validators_2.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 int main(int argc, const char ** argv)
 {
@@ -25,6 +24,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "integer given by user passed validation: " << myint << "\n";
+    std::cerr << "integer given by user passed validation: " << myint << "\n";
     return 0;
 }

--- a/test/snippet/validators_3.cpp
+++ b/test/snippet/validators_3.cpp
@@ -1,6 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
-#include <seqan3/std/filesystem>
 
 int main(int argc, const char ** argv)
 {
@@ -26,6 +24,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "filename given by user passed validation: " << myfile << "\n";
+    std::cerr << "filename given by user passed validation: " << myfile << "\n";
     return 0;
 }

--- a/test/snippet/validators_4.cpp
+++ b/test/snippet/validators_4.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 int main(int argc, const char ** argv)
 {
@@ -25,6 +24,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "email address given by user passed validation: " << my_string << "\n";
+    std::cerr << "email address given by user passed validation: " << my_string << "\n";
     return 0;
 }

--- a/test/snippet/validators_chaining.cpp
+++ b/test/snippet/validators_chaining.cpp
@@ -1,5 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/std/filesystem>
 
 int main(int argc, const char ** argv)
 {

--- a/test/snippet/validators_input_directory.cpp
+++ b/test/snippet/validators_input_directory.cpp
@@ -1,6 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
-#include <seqan3/std/filesystem>
 
 int main(int argc, const char ** argv)
 {
@@ -25,6 +23,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "directory given by user passed validation: " << mydir << "\n";
+    std::cerr << "directory given by user passed validation: " << mydir << "\n";
     return 0;
 }

--- a/test/snippet/validators_input_file.cpp
+++ b/test/snippet/validators_input_file.cpp
@@ -1,6 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
-#include <seqan3/std/filesystem>
 
 int main(int argc, const char ** argv)
 {
@@ -25,6 +23,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "filename given by user passed validation: " << myfile << "\n";
+    std::cerr << "filename given by user passed validation: " << myfile << "\n";
     return 0;
 }

--- a/test/snippet/validators_input_file_ext_from_file.cpp
+++ b/test/snippet/validators_input_file_ext_from_file.cpp
@@ -1,20 +1,20 @@
-#include <sharg/validators.hpp>
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sequence_file/input.hpp>
+
+#include <sharg/validators.hpp>
 
 int main()
 {
     // Default constructed validator has an empty extension list.
     sharg::input_file_validator validator1{};
-    seqan3::debug_stream << validator1.get_help_page_message() << '\n';
+    std::cerr << validator1.get_help_page_message() << '\n';
 
     // Specify your own extensions for the input file.
     sharg::input_file_validator validator2{std::vector{std::string{"exe"}, std::string{"fasta"}}};
-    seqan3::debug_stream << validator2.get_help_page_message() << '\n';
+    std::cerr << validator2.get_help_page_message() << '\n';
 
     // Give the seqan3 file type as a template argument to get all valid extensions for this file.
     sharg::input_file_validator<seqan3::sequence_file_input<>> validator3{};
-    seqan3::debug_stream << validator3.get_help_page_message() << '\n';
+    std::cerr << validator3.get_help_page_message() << '\n';
 
     return 0;
 }

--- a/test/snippet/validators_output_directory.cpp
+++ b/test/snippet/validators_output_directory.cpp
@@ -1,6 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
-#include <seqan3/std/filesystem>
 
 int main(int argc, const char ** argv)
 {
@@ -26,6 +24,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "directory given by user passed validation: " << mydir << "\n";
+    std::cerr << "directory given by user passed validation: " << mydir << "\n";
     return 0;
 }

--- a/test/snippet/validators_output_file.cpp
+++ b/test/snippet/validators_output_file.cpp
@@ -1,6 +1,4 @@
 #include <sharg/all.hpp>
-#include <seqan3/core/debug_stream.hpp>
-#include <seqan3/std/filesystem>
 
 int main(int argc, const char ** argv)
 {
@@ -33,6 +31,6 @@ int main(int argc, const char ** argv)
         return -1;
     }
 
-    seqan3::debug_stream << "filename given by user passed validation: " << myfile << "\n";
+    std::cerr << "filename given by user passed validation: " << myfile << "\n";
     return 0;
 }

--- a/test/snippet/validators_output_file_ext_from_file.cpp
+++ b/test/snippet/validators_output_file_ext_from_file.cpp
@@ -1,24 +1,24 @@
-#include <sharg/validators.hpp>
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/io/sequence_file/output.hpp>
+
+#include <sharg/validators.hpp>
 
 int main()
 {
     // Default constructed validator has an empty extension list.
     sharg::output_file_validator validator1{sharg::output_file_open_options::create_new};
-    seqan3::debug_stream << validator1.get_help_page_message() << '\n';
+    std::cerr << validator1.get_help_page_message() << '\n';
 
     // Specify your own extensions for the output file.
     sharg::output_file_validator validator2{sharg::output_file_open_options::create_new,
                                              std::vector{std::string{"exe"}, std::string{"fasta"}}};
-    seqan3::debug_stream << validator2.get_help_page_message() << '\n';
+    std::cerr << validator2.get_help_page_message() << '\n';
 
     // Give the seqan3 file type as a template argument to get all valid extensions for this file.
     sharg::output_file_validator<seqan3::sequence_file_output<>> validator3
     {
         sharg::output_file_open_options::create_new
     };
-    seqan3::debug_stream << validator3.get_help_page_message() << '\n';
+    std::cerr << validator3.get_help_page_message() << '\n';
 
     return 0;
 }

--- a/test/unit/detail/format_help_test.cpp
+++ b/test/unit/detail/format_help_test.cpp
@@ -5,13 +5,9 @@
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------------
 
-#include <fstream>
-#include <seqan3/std/ranges>
-
 #include <gtest/gtest.h>
 
 #include <sharg/argument_parser.hpp>
-#include <sharg/detail/format_help.hpp>
 
 // reused global variables
 std::string std_cout;

--- a/test/unit/detail/format_html_test.cpp
+++ b/test/unit/detail/format_html_test.cpp
@@ -8,8 +8,6 @@
 #include <gtest/gtest.h>
 
 #include <sharg/argument_parser.hpp>
-#include <sharg/detail/format_html.hpp>
-#include <seqan3/utility/char_operations/predicate.hpp>
 
 TEST(html_format, empty_information)
 {

--- a/test/unit/detail/format_man_test.cpp
+++ b/test/unit/detail/format_man_test.cpp
@@ -5,13 +5,9 @@
 // shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
 // -----------------------------------------------------------------------------------------------------------
 
-#include <string>
-#include <vector>
-
 #include <gtest/gtest.h>
 
 #include <sharg/argument_parser.hpp>
-#include <sharg/detail/format_man.hpp>
 
 // Reused global variables
 struct format_man_test : public ::testing::Test

--- a/test/unit/detail/version_check_debug_test.cpp
+++ b/test/unit/detail/version_check_debug_test.cpp
@@ -9,6 +9,4 @@
     #undef NDEBUG // test in debug mode
 #endif
 
-#include <string>
-
 #include "version_check_test.hpp"

--- a/test/unit/detail/version_check_release_test.cpp
+++ b/test/unit/detail/version_check_release_test.cpp
@@ -9,6 +9,4 @@
     #define NDEBUG // test in release mode
 #endif
 
-#include <string>
-
 #include "version_check_test.hpp"

--- a/test/unit/detail/version_check_test.hpp
+++ b/test/unit/detail/version_check_test.hpp
@@ -7,13 +7,9 @@
 
 #include <gtest/gtest.h>
 
-#include <iostream>
-#include <fstream>
-#include <chrono>
-#include <stdlib.h>
+#include <seqan3/test/tmp_filename.hpp>
 
 #include <sharg/argument_parser.hpp>
-#include <seqan3/test/tmp_filename.hpp>
 
 //------------------------------------------------------------------------------
 // test fixtures

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -7,13 +7,10 @@
 
 #include <gtest/gtest.h>
 
-#include <seqan3/std/filesystem>
-#include <fstream>
-#include <seqan3/std/ranges>
-
-#include <sharg/argument_parser.hpp>
 #include <seqan3/test/file_access.hpp>
 #include <seqan3/test/tmp_filename.hpp>
+
+#include <sharg/argument_parser.hpp>
 
 struct dummy_file
 {


### PR DESCRIPTION
Commit 1 resolves #4 
Resolves #25

* Remove unnecessary includes in `test/unit` and `test/snippet`
* Above includes trivial replacements: `seqan3::debug_stream` -> `std::cerr`
* Sort includes: seqan3 gets its own block -> should vanish once we are independent :)
* Minimize std includes
* Minimize seqan3 includes
* Minimize sharg includes
* Adds header test
* Adds CI for header test