### PR TITLE
[MISC] Remove predicate.hpp from format_parse.

### DIFF
--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -13,7 +13,6 @@
 #pragma once
 
 #include <seqan3/std/charconv>
-#include <seqan3/utility/char_operations/predicate.hpp>
 
 #include <sharg/detail/format_base.hpp>
 


### PR DESCRIPTION
Follow up on #28. Forgot to remove the include.