### PR TITLE
[FEATURE] Adapt the version checker to sharg.

### DIFF
--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -587,7 +587,7 @@ public:
      * VERSION
      *     Last update: 12.01.2017
      *     Penguin_Parade version: 2.0.0
-     *     Sharg version: 1.0.0
+     *     Sharg version: 0.1.0
      * ```
      */
     argument_parser_meta_data info;

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -92,7 +92,7 @@ namespace sharg
  * VERSION
  *     Last update:
  *     Grade-Average version:
- *     SeqAn version: 3.0.0
+ *     Sharg version: 0.1.0
  *
  * ```
  *
@@ -363,7 +363,7 @@ public:
      * VERSION
      *     Last update:
      *     The-Age-App version:
-     *     SeqAn version: 3.0.0
+     *     Sharg version: 0.1.0
      *
      * Thanks for using The-Age-App!
      *
@@ -587,7 +587,7 @@ public:
      * VERSION
      *     Last update: 12.01.2017
      *     Penguin_Parade version: 2.0.0
-     *     SeqAn version: 3.0.0
+     *     Sharg version: 1.0.0
      * ```
      */
     argument_parser_meta_data info;

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -420,7 +420,7 @@ protected:
         derived_t().print_section("Version");
         derived_t().print_line(derived_t().in_bold("Last update: ") + meta.date, false);
         derived_t().print_line(derived_t().in_bold(meta.app_name + " version: ") + meta.version, false);
-        derived_t().print_line(derived_t().in_bold("SeqAn version: ") + version_str, false);
+        derived_t().print_line(derived_t().in_bold("Sharg version: ") + version_str, false);
 
         if (!empty(meta.url))
         {

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -114,7 +114,7 @@ public:
      *    * If the app is unregistered (no version information is available at the server) the developer will be
      *      notified that he has the possibility of registering his application with us
      *      (see sharg::version_checker::message_unregistered_app).
-     *    * If the current Sharg version is smaller then the one returned by the server call, the developer is notified
+     *    * If the current Sharg version is smaller than the one returned by the server call, the developer is notified
      *      that he may update to the newest Sharg version (see sharg::version_checker::message_sharg_update).
      *    * If the current app version is greater than the one returned by the server call, we assume that the
      *      developer has released a new version and is notified to send us the new version
@@ -190,7 +190,7 @@ public:
                               " " +
                               out_file.string() +
                               " " +
-                              std::string{"http://seqan-update.informatik.uni-tuebingen.de/check/SeqAn-Sharg_"} +
+                              std::string{"https://seqan-update.informatik.uni-tuebingen.de/check/SeqAn-Sharg_"} +
 #ifdef __linux
                               "Linux" +
 #elif __APPLE__
@@ -239,7 +239,7 @@ public:
         // If this did not fail we, create the seqan subdirectory.
         if (!err)
         {
-            tmp_path /= "seqan"; // although sharg performs the version check, as it belongs to seqan this is fine.
+            tmp_path /= "seqan"; // sharg is part of seqan, so the naming is fine.
             create_directory(tmp_path, err);
         }
 

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -190,7 +190,7 @@ public:
                               " " +
                               out_file.string() +
                               " " +
-                              std::string{"http://seqan-update.informatik.uni-tuebingen.de/check/SeqAn3_"} +
+                              std::string{"http://seqan-update.informatik.uni-tuebingen.de/check/SeqAn-Sharg_"} +
 #ifdef __linux
                               "Linux" +
 #elif __APPLE__

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -78,7 +78,7 @@ public:
         if (!app_url.empty())
         {
             message_app_update.pop_back(); // remove second newline
-            message_app_update.append("[APP INFO] :: Visit " + app_url + " for updates.\n\n");
+            message_app_update.append("[APP VERSION INFO] :: Visit " + app_url + " for updates.\n\n");
         }
 
 #if defined(NDEBUG)
@@ -108,14 +108,14 @@ public:
      *    * content is a timestamp: The "time-of-last-version-check" is read from file. The function only
      *                              continues if the last version check is more than a day old.
      *
-     * 2. If a version file exists, the app version and seqan3 version are compared to the current ones and the
+     * 2. If a version file exists, the app version and Sharg version are compared to the current ones and the
      *    the following message may be printed:
      *    **Debug mode** (directed at the developer of the application)
      *    * If the app is unregistered (no version information is available at the server) the developer will be
      *      notified that he has the possibility of registering his application with us
      *      (see sharg::version_checker::message_unregistered_app).
-     *    * If the current seqan version is smaller then the one returned by the server call, the developer is notified
-     *      that he may update to the newest seqan3 version (see sharg::version_checker::message_seqan3_update).
+     *    * If the current Sharg version is smaller then the one returned by the server call, the developer is notified
+     *      that he may update to the newest Sharg version (see sharg::version_checker::message_sharg_update).
      *    * If the current app version is greater than the one returned by the server call, we assume that the
      *      developer has released a new version and is notified to send us the new version
      *      (see sharg::version_checker::message_registered_app_update).
@@ -127,7 +127,7 @@ public:
     {
         std::array<int, 3> empty_version{0, 0, 0};
         std::array<int, 3> srv_app_version{};
-        std::array<int, 3> srv_seqan_version{};
+        std::array<int, 3> srv_sharg_version{};
 
         std::ifstream version_file{cookie_path / (name + ".version")};
 
@@ -143,19 +143,19 @@ public:
             std::cerr << message_unregistered_app;
 #endif // !defined(NDEBUG)
 
-            std::getline(version_file, line); // get second line which should only contain the version number of seqan
-            srv_seqan_version = get_numbers_from_version_string(line);
+            std::getline(version_file, line); // get second line which should only contain the version number of sharg
+            srv_sharg_version = get_numbers_from_version_string(line);
 
             version_file.close();
         }
 
-#if !defined(NDEBUG) // only check seqan version in debug
-        if (srv_seqan_version != empty_version)
+#if !defined(NDEBUG) // only check Sharg version in debug
+        if (srv_sharg_version != empty_version)
         {
-            std::array<int, 3> seqan_version = {SEQAN3_VERSION_MAJOR, SEQAN3_VERSION_MINOR, SEQAN3_VERSION_PATCH};
+            std::array<int, 3> sharg_version = {SHARG_VERSION_MAJOR, SHARG_VERSION_MINOR, SHARG_VERSION_PATCH};
 
-            if (seqan_version < srv_seqan_version)
-                std::cerr << message_seqan3_update;
+            if (sharg_version < srv_sharg_version)
+                std::cerr << message_sharg_update;
         }
 #endif
 
@@ -239,7 +239,7 @@ public:
         // If this did not fail we, create the seqan subdirectory.
         if (!err)
         {
-            tmp_path /= "seqan";
+            tmp_path /= "seqan"; // although sharg performs the version check, as it belongs to seqan this is fine.
             create_directory(tmp_path, err);
         }
 
@@ -402,27 +402,27 @@ public:
 
     //!\brief The identification string that may appear in the version file if an app is unregistered.
     static constexpr std::string_view unregistered_app = "UNREGISTERED_APP";
-    //!\brief The message directed to the developer of the app if a new seqan3 version is available.
-    static constexpr std::string_view message_seqan3_update =
-        "[SEQAN3 INFO] :: A new SeqAn version is available online.\n"
-        "[SEQAN3 INFO] :: Please visit www.github.com/seqan/seqan3.git for an update\n"
-        "[SEQAN3 INFO] :: or inform the developer of this app.\n"
-        "[SEQAN3 INFO] :: If you don't wish to receive further notifications, set --version-check false.\n\n";
+    //!\brief The message directed to the developer of the app if a new sharg version is available.
+    static constexpr std::string_view message_sharg_update =
+        "[SHARG VERSION INFO] :: A new Sharg version is available online.\n"
+        "[SHARG VERSION INFO] :: Please visit www.github.com/seqan/sharg-parser.git for an update\n"
+        "[SHARG VERSION INFO] :: or inform the developer of this app.\n"
+        "[SHARG VERSION INFO] :: If you don't wish to receive further notifications, set --version-check false.\n\n";
     //!\brief The message directed to the developer of the app if the app is not yet registered with us.
     static constexpr std::string_view message_unregistered_app =
-        "[SEQAN3 INFO] :: Thank you for using SeqAn!\n"
-        "[SEQAN3 INFO] :: Do you wish to register your app for update notifications?\n"
-        "[SEQAN3 INFO] :: Just send an email to support@seqan.de with your app name and version number.\n"
-        "[SEQAN3 INFO] :: If you don't wish to receive further notifications, set --version-check false.\n\n";
+        "[SHARG VERSION INFO] :: Thank you for using Sharg!\n"
+        "[SHARG VERSION INFO] :: Do you wish to register your app for update notifications?\n"
+        "[SHARG VERSION INFO] :: Just send an email to support@seqan.de with your app name and version number.\n"
+        "[SHARG VERSION INFO] :: If you don't wish to receive further notifications, set --version-check false.\n\n";
     //!\brief The message directed to the developer if the application is registered but under a lower version.
     static constexpr std::string_view message_registered_app_update =
-        "[APP INFO] :: We noticed the app version you use is newer than the one registered with us.\n"
-        "[APP INFO] :: Please send us an email with the new version so we can correct it (support@seqan.de)\n\n";
+        "[APP VERSION INFO] :: We noticed the app version you use is newer than the one registered with us.\n"
+        "[APP VERSION INFO] :: Please send us an email with the new version so we can correct it (support@seqan.de)\n\n";
     //!\brief The message directed to the user of the app if a new app version is available.
     std::string message_app_update =
-        "[APP INFO] :: A new version of this application is now available.\n"
-        "[APP INFO] :: If you don't wish to receive further notifications, set --version-check false.\n\n";
-        /*Might be extended if a url is given on construction.*/
+        "[APP VERSION INFO] :: A new version of this application is now available.\n"
+        "[APP VERSION INFO] :: If you don't wish to receive further notifications, set --version-check false.\n\n";
+        /*Will be extended if a url is given on construction of version_check.*/
 
     //!\brief The environment name of the home environment used by getenv()
     static constexpr char const * home_env_name

--- a/test/unit/detail/format_help_test.cpp
+++ b/test/unit/detail/format_help_test.cpp
@@ -39,7 +39,7 @@ std::string const basic_options_str = "OPTIONS\n"
 std::string const basic_version_str = "VERSION\n"
                                       "    Last update:\n"
                                       "    test_parser version:\n"
-                                      "    SeqAn version: " + std::string{sharg::sharg_version_cstring} + "\n";
+                                      "    Sharg version: " + std::string{sharg::sharg_version_cstring} + "\n";
 
 std::string license_text()
 {

--- a/test/unit/detail/format_html_test.cpp
+++ b/test/unit/detail/format_html_test.cpp
@@ -51,7 +51,7 @@ TEST(html_format, empty_information)
                            "<br>\n"
                            "<strong>empty_options version: </strong>\n"
                            "<br>\n"
-                           "<strong>SeqAn version: </strong>" + std::string{sharg::sharg_version_cstring} + "\n"
+                           "<strong>Sharg version: </strong>" + std::string{sharg::sharg_version_cstring} + "\n"
                            "<br>\n"
                            "</p>\n"
                            "</body></html>");
@@ -167,7 +167,7 @@ TEST(html_format, full_information_information)
                           "<br>\n"
                           "<strong>program_full_options version: </strong>\n"
                           "<br>\n"
-                          "<strong>SeqAn version: </strong>" + std::string{sharg::sharg_version_cstring} + "\n"
+                          "<strong>Sharg version: </strong>" + std::string{sharg::sharg_version_cstring} + "\n"
                           "<br>\n"
                           "</p>\n"
                           "<h2>Url</h2>\n"

--- a/test/unit/detail/format_man_test.cpp
+++ b/test/unit/detail/format_man_test.cpp
@@ -82,7 +82,7 @@ struct format_man_test : public ::testing::Test
     R"(.br)" "\n"
     R"(\fBdefault version: \fR01.01.01)" "\n"
     R"(.br)" "\n"
-    R"(\fBSeqAn version: \fR)" + version_str + "\n";
+    R"(\fBSharg version: \fR)" + version_str + "\n";
 
     // Full info parser initialisation
     void dummy_init(sharg::argument_parser & parser)
@@ -148,7 +148,7 @@ TEST_F(format_man_test, empty_information)
     R"(.br)" "\n"
     R"(\fBdefault version: \fR01.01.01)" "\n"
     R"(.br)" "\n"
-    R"(\fBSeqAn version: \fR)" + version_str + "\n";
+    R"(\fBSharg version: \fR)" + version_str + "\n";
 
     // Test the dummy parser with minimal information.
     testing::internal::CaptureStdout();

--- a/test/unit/detail/version_check_test.hpp
+++ b/test/unit/detail/version_check_test.hpp
@@ -196,6 +196,34 @@ TEST_F(sanity_checks, create_and_delete_files)
     EXPECT_FALSE(std::filesystem::exists(app_timestamp_filename()));
 }
 
+TEST_F(sanity_checks, cookie)
+{
+    const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
+    auto [out, err, app_call_succeeded] = simulate_argument_parser(3, argv);
+
+    if (app_call_succeeded)
+    {
+        // Write out the cookie for inspection.
+        // When manually executing this test, check that the cookie looks like this:
+        // ```
+        // UNREGISTERED_APP
+        // X.X.X <-- Should reflect the latest release of sharg
+        // ```
+        // This should not be tested via EXPECT_EQ(..) because then sharg tests fail if the server wasn't
+        // configured correctly and we want to be independent of the server.
+        std::cout << "Cookie:" << std::endl;
+        std::ifstream app_version_file{app_version_filename()};
+        std::string line;
+        std::getline(app_version_file, line);
+        std::cout << line << " <-- Should be UNREGISTERED_APP!" << std::endl;
+        std::getline(app_version_file, line);
+        std::cout << line
+                  << " <-- Should be the latest Sharg version! "
+                  << "Updates done here: https://github.com/OpenMS/usage_plots/blob/master/seqan_versions.txt"
+                  << std::endl;
+    }
+}
+
 //------------------------------------------------------------------------------
 // version checks
 //------------------------------------------------------------------------------
@@ -213,20 +241,6 @@ TEST_F(version_check, option_on)
     if (app_call_succeeded)
     {
         EXPECT_TRUE(std::filesystem::exists(app_version_filename()));
-
-        // This is not an actual check s.t. the test does not fail because there is something wrong with
-        // the server in Tuebingen. But upon manual execution of the test this can give valuable insight
-        // on whats happening.
-        std::cout << "Cookie:" << std::endl;
-        std::ifstream app_version_file{app_version_filename()};
-        std::string line;
-        std::getline(app_version_file, line);
-        std::cout << line << " << Should be UNREGISTERED_APP!" << std::endl;
-        std::getline(app_version_file, line);
-        std::cout << line
-                  << " << Should be the latest Sharg version! "
-                  << "Updates done here: https://github.com/OpenMS/usage_plots/blob/master/seqan_versions.txt"
-                  << std::endl;
     }
     else
     {

--- a/test/unit/detail/version_check_test.hpp
+++ b/test/unit/detail/version_check_test.hpp
@@ -213,6 +213,20 @@ TEST_F(version_check, option_on)
     if (app_call_succeeded)
     {
         EXPECT_TRUE(std::filesystem::exists(app_version_filename()));
+
+        // This is not an actual check s.t. the test does not fail because there is something wrong with
+        // the server in Tuebingen. But upon manual execution of the test this can give valuable insight
+        // on whats happening.
+        std::cout << "Cookie:" << std::endl;
+        std::ifstream app_version_file{app_version_filename()};
+        std::string line;
+        std::getline(app_version_file, line);
+        std::cout << line << " << Should be UNREGISTERED_APP!" << std::endl;
+        std::getline(app_version_file, line);
+        std::cout << line
+                  << " << Should be the latest Sharg version! "
+                  << "Updates done here: https://github.com/OpenMS/usage_plots/blob/master/seqan_versions.txt"
+                  << std::endl;
     }
     else
     {
@@ -325,6 +339,7 @@ TEST_F(version_check, option_off)
 
     // no timestamp is written since the decision was made explicitly
     EXPECT_FALSE(std::filesystem::exists(app_version_filename())) << app_version_filename();
+    EXPECT_FALSE(std::filesystem::exists(app_timestamp_filename())) << app_timestamp_filename();
 
     EXPECT_TRUE(remove_files_from_path()); // clear files again
 

--- a/test/unit/detail/version_check_test.hpp
+++ b/test/unit/detail/version_check_test.hpp
@@ -342,9 +342,12 @@ TEST_F(version_check, option_off)
     EXPECT_FALSE(std::filesystem::exists(app_timestamp_filename())) << app_timestamp_filename();
 
     EXPECT_TRUE(remove_files_from_path()); // clear files again
+}
 
+TEST_F(version_check, option_off_with_help_page)
+{
     // Version check option always needs to be parsed, even if special formats get selected
-    const char * argv2[4] = {app_name.c_str(), "-h", OPTION_VERSION_CHECK, OPTION_OFF};
+    const char * argv[4] = {app_name.c_str(), "-h", OPTION_VERSION_CHECK, OPTION_OFF};
 
     std::string previous_value{};
     if (char * env = std::getenv("SHARG_NO_VERSION_CHECK"))
@@ -353,7 +356,7 @@ TEST_F(version_check, option_off)
         unsetenv("SHARG_NO_VERSION_CHECK");
     }
 
-    sharg::argument_parser parser{app_name, 4, argv2};
+    sharg::argument_parser parser{app_name, 4, argv};
     parser.info.version = "2.3.4";
 
     EXPECT_EXIT(parser.parse(), ::testing::ExitedWithCode(EXIT_SUCCESS), "");

--- a/test/unit/detail/version_check_test.hpp
+++ b/test/unit/detail/version_check_test.hpp
@@ -356,13 +356,13 @@ TEST_F(version_check, option_off)
     EXPECT_TRUE(remove_files_from_path()); // clear files again
 }
 
-// case: the current argument parser has a smaller seqan version than is present in the version file
+// case: the current argument parser has a smaller Sharg version than is present in the version file
 #if !defined(NDEBUG)
-TEST_F(version_check, smaller_seqan3_version)
+TEST_F(version_check, smaller_sharg_version)
 {
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
-    // create version file with euqal app version and a greater seqan version than the current
+    // create version file with euqal app version and a greater Sharg version than the current
     create_file(app_version_filename(), std::string{"2.3.4\n20.5.9"});
 
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
@@ -372,7 +372,7 @@ TEST_F(version_check, smaller_seqan3_version)
     (void) app_call_succeeded;
 
     EXPECT_EQ(out, "");
-    EXPECT_EQ(err, sharg::detail::version_checker::message_seqan3_update);
+    EXPECT_EQ(err, sharg::detail::version_checker::message_sharg_update);
 
     EXPECT_TRUE(std::regex_match(read_file(app_timestamp_filename()), timestamp_regex));
 
@@ -384,7 +384,7 @@ TEST_F(version_check, greater_app_version)
 {
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
-    // create version file with equal seqan version and a smaller app version than the current
+    // create version file with equal Sharg version and a smaller app version than the current
     ASSERT_TRUE(create_file(app_version_filename(), std::string{"1.5.9\n"} + sharg::sharg_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message
@@ -405,7 +405,7 @@ TEST_F(version_check, unregistered_app)
 {
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
-    // create version file with equal seqan version and a smaller app version than the current
+    // create version file with equal Sharg version and a smaller app version than the current
     ASSERT_TRUE(create_file(app_version_filename(), std::string{"UNREGISTERED_APP\n"} + sharg::sharg_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message
@@ -429,7 +429,7 @@ TEST_F(version_check, smaller_app_version)
 {
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
-    // create version file with equal seqan version and a greater app version than the current
+    // create version file with equal Sharg version and a greater app version than the current
     ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n"} + sharg::sharg_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)
@@ -457,7 +457,7 @@ TEST_F(version_check, smaller_app_version_custom_url)
 
     const char * argv[3] = {app_name.c_str(), OPTION_VERSION_CHECK, OPTION_ON};
 
-    // create version file with equal seqan version and a greater app version than the current
+    // create version file with equal Sharg version and a greater app version than the current
     ASSERT_TRUE(create_file(app_version_filename(), std::string{"20.5.9\n"} + sharg::sharg_version_cstring));
 
     // create timestamp file that dates one day before current to trigger a message (one day = 86400 seconds)

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -44,7 +44,7 @@ std::string const basic_options_str = "OPTIONS\n"
 std::string const basic_version_str = "VERSION\n"
                                       "    Last update:\n"
                                       "    test_parser version:\n"
-                                      "    SeqAn version: " + std::string{sharg::sharg_version_cstring} + "\n";
+                                      "    Sharg version: " + std::string{sharg::sharg_version_cstring} + "\n";
 
 namespace seqan3::detail
 {


### PR DESCRIPTION
Part of #31 

Prior to this PR the following has been done:

* Sharg version has also been added to the seqan_versions.txt 
  https://github.com/OpenMS/usage_plots/pull/19
* Server script was changed to return the sharg version if URL is `.../SeqAn-Sharg` (instead of `SeqAn3`). See full script [here](https://gist.github.com/smehringer/13f7534ce893e05b5d16c18cfcda0297)
* Script has been updated on server in Tuebingen by @timosachsenberg (17.12.2021)

This PR does the following (by commit):

1. Changes most occurences of "seqan" to sharg
   Exceptions (Open TODO): Notifications still link to seqan3 wiki page
2. Changes the URL of the server call to `SeqAn-Sharg` to get correct cookies
3. Adds small print out in test that comes in handy when manually inspecting the version tests.
4. Tiny :nail_care: splitting two tests