### PR TITLE
[MISC] Remove dependency of seqan3::detail::type_name_as_string.

### DIFF
--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -13,10 +13,9 @@
 
 #pragma once
 
-#include <sharg/detail/type_name_as_string.hpp>
-
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/concept.hpp>
+#include <sharg/detail/type_name_as_string.hpp>
 #include <sharg/validators.hpp>
 
 namespace sharg::detail

--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include <seqan3/utility/detail/type_name_as_string.hpp>
+#include <sharg/detail/type_name_as_string.hpp>
 
 #include <sharg/auxiliary.hpp>
 #include <sharg/detail/concept.hpp>
@@ -67,7 +67,7 @@ protected:
         else if constexpr (std::is_same_v<type, std::filesystem::path>)
             return "std::filesystem::path";
         else
-            return seqan3::detail::type_name_as_string<value_type>;
+            return sharg::detail::type_name_as_string<value_type>;
     }
 
     /*!\brief Returns the `value_type` of the input container as a string (reflection).
@@ -255,7 +255,7 @@ public:
         {
             ++positional_option_count;
             derived_t().print_list_item(seqan3::detail::to_string("\\fBARGUMENT-", positional_option_count, "\\fP ",
-                                                          option_type_and_list_info(value)),
+                                                                  option_type_and_list_info(value)),
                                         desc +
                                         // a list at the end may be empty and thus have a default value
                                         ((detail::is_container_option<option_type>)

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -284,7 +284,7 @@ private:
     }
 
     /*!\brief Tries to parse an input string into a value using the stream `operator>>`.
-     * \tparam option_t Must model sharg::seqan3::input_stream_over.
+     * \tparam option_t Must model seqan3::input_stream_over.
      * \param[out] value Stores the parsed value.
      * \param[in] in The input argument to be parsed.
      * \returns sharg::option_parse_result::error if `in` could not be parsed via the stream
@@ -331,7 +331,8 @@ private:
                 });
 
             throw user_input_error{seqan3::detail::to_string("You have chosen an invalid input value: ", in,
-                                                     ". Please use one of: ", key_value_pairs | std::views::keys)};
+                                                             ". Please use one of: ",
+                                                             key_value_pairs | std::views::keys)};
         }
         else
         {

--- a/include/sharg/detail/type_name_as_string.hpp
+++ b/include/sharg/detail/type_name_as_string.hpp
@@ -1,0 +1,80 @@
+// -----------------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides traits to inspect some information of a type, for example its name.
+ * \author Lydia Buntrock <lydia.buntrock AT fu-berlin.de>
+ */
+
+#pragma once
+
+#if defined(__GNUC__) || defined(__clang__)
+#include <cxxabi.h>
+#endif // defined(__GNUC__) || defined(__clang__)
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <typeinfo>
+
+#include <sharg/platform.hpp>
+
+namespace sharg::detail
+{
+
+/*!\brief Defines the human-readable name of the given type using the
+          [typeid](https://en.cppreference.com/w/cpp/language/typeid) operator.
+ *
+ * \tparam type The type to get the human-readable name for.
+ *
+ * \details
+ *
+ * On gcc and clang std::type_info only returns a mangled name.
+ * The mangled name can be converted to human-readable form using implementation-specific API such as
+ * abi::__cxa_demangle. In other implementations the name returned is already human-readable.
+ *
+ * \note The returned name is implementation defined and might change between different tool chains.
+ */
+template <typename type>
+inline std::string const type_name_as_string = [] ()
+{
+    std::string demangled_name{};
+#if defined(__GNUC__) || defined(__clang__) // clang and gcc only return a mangled name.
+    using safe_ptr_t = std::unique_ptr<char, std::function<void(char *)>>;
+
+    // https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html
+    int status{};
+    safe_ptr_t demangled_name_ptr{abi::__cxa_demangle(typeid(type).name(), 0, 0, &status),
+                                  [] (char * name_ptr) { free(name_ptr); }};
+
+    // We exclude status != 0, because this code can't be reached normally, only if there is a defect in the compiler
+    // itself, since the type is directly given by the compiler. See https://github.com/seqan/seqan3/pull/2311.
+    // LCOV_EXCL_START
+    if (status != 0)
+        return std::string{typeid(type).name()} +
+               " (abi::__cxa_demangle error status (" + std::to_string(status) + "): " +
+               (status == -1 ? "A memory allocation failure occurred." :
+               (status == -2 ? "mangled_name is not a valid name under the C++ ABI mangling rules." :
+               (status == -3 ? "One of the arguments is invalid." : "Unknown Error"))) + ")";
+    // LCOV_EXCL_STOP
+
+    demangled_name = std::string{std::addressof(*demangled_name_ptr)};
+#else // e.g. MSVC
+    demangled_name = typeid(type).name();
+#endif // defined(__GNUC__) || defined(__clang__)
+
+    if constexpr (std::is_const_v<std::remove_reference_t<type>>)
+        demangled_name += " const";
+    if constexpr (std::is_lvalue_reference_v<type>)
+        demangled_name += " &";
+    if constexpr (std::is_rvalue_reference_v<type>)
+        demangled_name += " &&";
+
+    return demangled_name;
+}();
+
+}  // namespace sharg::detail

--- a/test/unit/detail/CMakeLists.txt
+++ b/test/unit/detail/CMakeLists.txt
@@ -17,5 +17,6 @@ sharg_test(format_html_test.cpp CYCLIC_DEPENDING_INCLUDES
             include-seqan3-argument_parser-detail-format_man.hpp)
 sharg_test(format_man_test.cpp)
 sharg_test(safe_filesystem_entry_test.cpp)
+sharg_test(type_name_as_string_test.cpp)
 sharg_test(version_check_debug_test.cpp)
 sharg_test(version_check_release_test.cpp)

--- a/test/unit/detail/type_name_as_string_test.cpp
+++ b/test/unit/detail/type_name_as_string_test.cpp
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <sharg/detail/type_name_as_string.hpp>
+
+#include <seqan3/utility/type_list/traits.hpp>
+#include <seqan3/utility/type_list/type_list.hpp>
+
+// Some test namespace to check if namespace information are preserved within the naming.
+namespace foo
+{
+template <typename ...type>
+struct bar
+{};
+} // namespace foo
+
+// Some types to test if type inspection works as expected.
+// Note that the returned name might differ between compiler vendors and thus must be adapted accordingly
+// in case this tests fails for those vendors.
+using reflection_types = ::testing::Types<char, char16_t const, char32_t &, short *, double const * const,
+                                          foo::bar<char> const &, foo::bar<foo::bar<char, double>>>;
+
+// Helper type list to use some traits functions on type lists.
+using as_type_list_t = seqan3::detail::transfer_template_args_onto_t<reflection_types, seqan3::type_list>;
+
+template <typename param_type>
+class type_inspection : public ::testing::Test
+{
+    // The corresponding list of names that should be generated. Must have the same order as `reflection_types`.
+    inline static const std::vector names{"char", "char16_t const", "char32_t &", "short*", "double const* const",
+                                          "foo::bar<char> const &", "foo::bar<foo::bar<char, double> >"};
+
+public:
+    // Returns the name of the type according to the list of names defined above.
+    std::string expected_name()
+    {
+        return names[seqan3::list_traits::find<param_type, as_type_list_t>];
+    }
+};
+
+// Register test.
+TYPED_TEST_SUITE(type_inspection, reflection_types, );
+
+TYPED_TEST(type_inspection, type_name_as_string)
+{
+    EXPECT_EQ(sharg::detail::type_name_as_string<TypeParam>, this->expected_name());
+}

--- a/test/unit/detail/type_name_as_string_test.cpp
+++ b/test/unit/detail/type_name_as_string_test.cpp
@@ -7,10 +7,9 @@
 
 #include <gtest/gtest.h>
 
-#include <sharg/detail/type_name_as_string.hpp>
+#include <type_traits>
 
-#include <seqan3/utility/type_list/traits.hpp>
-#include <seqan3/utility/type_list/type_list.hpp>
+#include <sharg/detail/type_name_as_string.hpp>
 
 // Some test namespace to check if namespace information are preserved within the naming.
 namespace foo
@@ -26,21 +25,30 @@ struct bar
 using reflection_types = ::testing::Types<char, char16_t const, char32_t &, short *, double const * const,
                                           foo::bar<char> const &, foo::bar<foo::bar<char, double>>>;
 
-// Helper type list to use some traits functions on type lists.
-using as_type_list_t = seqan3::detail::transfer_template_args_onto_t<reflection_types, seqan3::type_list>;
-
 template <typename param_type>
 class type_inspection : public ::testing::Test
 {
-    // The corresponding list of names that should be generated. Must have the same order as `reflection_types`.
-    inline static const std::vector names{"char", "char16_t const", "char32_t &", "short*", "double const* const",
-                                          "foo::bar<char> const &", "foo::bar<foo::bar<char, double> >"};
 
 public:
     // Returns the name of the type according to the list of names defined above.
-    std::string expected_name()
+    std::string const expected_name() const
     {
-        return names[seqan3::list_traits::find<param_type, as_type_list_t>];
+        if constexpr (std::is_same_v<param_type, char>)
+            return "char";
+        else if constexpr (std::is_same_v<param_type, char16_t const>)
+            return "char16_t const";
+        else if constexpr (std::is_same_v<param_type, char32_t &>)
+            return "char32_t &";
+        else if constexpr (std::is_same_v<param_type, short *>)
+            return "short*";
+        else if constexpr (std::is_same_v<param_type, double const * const>)
+            return "double const* const";
+        else if constexpr (std::is_same_v<param_type, foo::bar<char> const &>)
+            return "foo::bar<char> const &";
+        else if constexpr (std::is_same_v<param_type, foo::bar<foo::bar<char, double>>>)
+            return "foo::bar<foo::bar<char, double> >";
+        else
+            throw std::runtime_error{"Encountered unknown type in test."};
     }
 };
 


### PR DESCRIPTION
Resolves #15

~New seqan3 includes in the new test file:~
~#include <seqan3/utility/type_list/traits.hpp>~
~#include <seqan3/utility/type_list/type_list.hpp>~