### PR TITLE
[MISC] Remove some occurrences of seqan3::detail::to_string that aren't necessary.

### DIFF
--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -14,8 +14,6 @@
 
 #include <set>
 
-#include <seqan3/core/debug_stream/detail/to_string.hpp>
-
 #include <sharg/detail/format_help.hpp>
 #include <sharg/detail/format_html.hpp>
 #include <sharg/detail/format_man.hpp>
@@ -390,9 +388,15 @@ public:
 
         if (std::holds_alternative<detail::format_parse>(format) && !subcommands.empty() && sub_parser == nullptr)
         {
-            throw too_few_arguments{seqan3::detail::to_string("You either forgot or misspelled the subcommand! Please specify"
-                                                      " which sub-program you want to use: one of ", subcommands,
-                                                      ". Use -h/--help for more information.")};
+            assert(!subcommands.empty());
+            std::string subcommands_str{"["};
+            for (std::string const & command : subcommands)
+                subcommands_str += command + ", ";
+            subcommands_str.replace(subcommands_str.size() - 2, 2, "]"); // replace last ", " by "]"
+
+            throw too_few_arguments{"You either forgot or misspelled the subcommand! Please specify which sub-program "
+                                    "you want to use: one of " + subcommands_str + ". Use -h/--help for more "
+                                    "information."};
         }
 
         if (app_version.decide_if_check_is_performed(version_check_dev_decision, version_check_user_decision))

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -461,7 +461,6 @@ public:
     void parse(argument_parser_meta_data const & parser_meta)
     {
         meta = parser_meta;
-        seqan3::debug_stream_type stream{std::cout};
         std::string seqan_license{
 R"(Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
 Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
@@ -491,28 +490,28 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.)"};
 
-        stream << std::string(80, '=') << "\n"
-               << in_bold("Copyright information for " + meta.app_name + ":\n")
-               << std::string(80, '-') << '\n';
+        std::cout << std::string(80, '=') << "\n"
+                  << in_bold("Copyright information for " + meta.app_name + ":\n")
+                  << std::string(80, '-') << '\n';
 
         if (!empty(meta.long_copyright))
         {
-            stream << to_text("\\fP") << meta.long_copyright << "\n";
+            std::cout << to_text("\\fP") << meta.long_copyright << "\n";
         }
         else if (!empty(meta.short_copyright))
         {
-            stream << in_bold(meta.app_name + " full copyright information not available. " +
+            std::cout << in_bold(meta.app_name + " full copyright information not available. " +
                               "Displaying short copyright information instead:\n" )
-                   << meta.short_copyright << "\n";
+                      << meta.short_copyright << "\n";
         }
         else
         {
-            stream << to_text("\\fP") << meta.app_name << " copyright information not available.\n";
+            std::cout << to_text("\\fP") << meta.app_name << " copyright information not available.\n";
         }
 
-        stream << std::string(80, '=') << '\n'
-               << in_bold("This program contains SeqAn code licensed under the following terms:\n")
-               << std::string(80, '-') << '\n' << seqan_license << '\n';
+        std::cout << std::string(80, '=') << '\n'
+                  << in_bold("This program contains SeqAn code licensed under the following terms:\n")
+                  << std::string(80, '-') << '\n' << seqan_license << '\n';
 
         std::exit(EXIT_SUCCESS);
     }

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -501,7 +501,7 @@ DAMAGE.)"};
         else if (!empty(meta.short_copyright))
         {
             std::cout << in_bold(meta.app_name + " full copyright information not available. " +
-                              "Displaying short copyright information instead:\n" )
+                                 "Displaying short copyright information instead:\n" )
                       << meta.short_copyright << "\n";
         }
         else

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -924,7 +924,7 @@ public:
     {
         std::regex rgx(pattern);
         if (!std::regex_match(cmp, rgx))
-            throw validation_error{seqan3::detail::to_string("Value ", cmp, " did not match the pattern ", pattern, ".")};
+            throw validation_error{"Value " + cmp + " did not match the pattern " + pattern + "."};
     }
 
     /*!\brief Tests whether every filename in list v matches the pattern.
@@ -949,7 +949,7 @@ public:
     //!\brief Returns a message that can be appended to the (positional) options help page info.
     std::string get_help_page_message() const
     {
-        return seqan3::detail::to_string("Value must match the pattern '", pattern, "'.");
+        return "Value must match the pattern '" + pattern + "'.";
     }
 
 private:

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -123,7 +123,7 @@ private:
     option_value_type max{};
 
     //!\brief The range as string
-    std::string valid_range_str;
+    std::string valid_range_str{};
 };
 
 /*!\brief A validator that checks whether a value is inside a list of valid values.
@@ -415,7 +415,7 @@ protected:
         if (extensions.empty())
             return "";
         else
-            return " Valid file extensions are: " + extensions_str + ".";
+            return "Valid file extensions are: " + extensions_str + ".";
     }
 
     /*!\brief Helper function that checks if a string is a suffix of another string. Case insensitive.
@@ -435,18 +435,16 @@ protected:
                });
     }
 
-    std::string create_extensions_str()
+    //!\brief Creates a std::string from the extensions list, e.g. "[ext, ext2]".
+    std::string const create_extensions_str() const
     {
-        std::string result{};
+        if (extensions.empty())
+            return "[]";
 
-        if (!extensions.empty())
-        {
-            result += "[";
-            for (std::string const & ext : extensions)
-                result += ext + ", ";
-            result.replace(result.size() - 2, 2, "]"); // repalce last ", " by "]"
-        }
-
+        std::string result{'['};
+        for (std::string const & ext : extensions)
+            result += ext + ", ";
+        result.replace(result.size() - 2, 2, "]"); // replace last ", " by "]"
         return result;
     }
 

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -575,6 +575,7 @@ public:
     std::string get_help_page_message() const
     {
         return "The input file must exist and read permissions must be granted." +
+               ((valid_extensions_help_page_message().empty()) ? std::string{} : std::string{" "}) +
                valid_extensions_help_page_message();
     }
 };
@@ -709,10 +710,19 @@ public:
     std::string get_help_page_message() const
     {
         if (mode == output_file_open_options::open_or_create)
-            return "Write permissions must be granted." + valid_extensions_help_page_message();
-        else // mode == create_new
-            return "The output file must not exist already and write permissions must be granted." +
+        {
+            return "Write permissions must be granted." +
+                   ((valid_extensions_help_page_message().empty()) ? std::string{} : std::string{" "}) +
                    valid_extensions_help_page_message();
+
+        }
+        else // mode == create_new
+        {
+            return "The output file must not exist already and write permissions must be granted." +
+                   ((valid_extensions_help_page_message().empty()) ? std::string{} : std::string{" "}) +
+                   valid_extensions_help_page_message();
+
+        }
     }
 
 private:

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -82,7 +82,7 @@ public:
      * \param[in] max_ Maximum set for the range to test.
      */
     arithmetic_range_validator(option_value_type const min_, option_value_type const max_) :
-        min{min_}, max{max_}
+        min{min_}, max{max_}, valid_range_str{"[" + std::to_string(min_) + "," + std::to_string(max_) + "]"}
     {}
 
     /*!\brief Tests whether cmp lies inside [`min`, `max`].
@@ -92,7 +92,7 @@ public:
     void operator()(option_value_type const & cmp) const
     {
         if (!((cmp <= max) && (cmp >= min)))
-            throw validation_error{seqan3::detail::to_string("Value ", cmp, " is not in range [", min, ",", max, "].")};
+            throw validation_error{"Value " + std::to_string(cmp) + " is not in range " + valid_range_str + "."};
     }
 
     /*!\brief Tests whether every element in \p range lies inside [`min`, `max`].
@@ -113,7 +113,7 @@ public:
     //!\brief Returns a message that can be appended to the (positional) options help page info.
     std::string get_help_page_message() const
     {
-        return seqan3::detail::to_string("Value must be in range [", min, ",", max, "].");
+        return std::string{"Value must be in range "} + valid_range_str + ".";
     }
 
 private:
@@ -122,6 +122,9 @@ private:
 
     //!\brief Maximum of the range to test.
     option_value_type max{};
+
+    //!\brief The range as string
+    std::string valid_range_str;
 };
 
 /*!\brief A validator that checks whether a value is inside a list of valid values.

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -1055,7 +1055,7 @@ public:
     //!\brief Returns a message that can be appended to the (positional) options help page info.
     std::string get_help_page_message() const
     {
-        return seqan3::detail::to_string(vali1.get_help_page_message(), " ", vali2.get_help_page_message());
+        return vali1.get_help_page_message() + " " + vali2.get_help_page_message();
     }
 
 private:


### PR DESCRIPTION
In all commits we don't really need the `seqan3::detail::to_string` which uses the `seqan3::debug_stream` because we only have std types and not seqan3 types.

Part of #41 