### PR TITLE
[MISC] Remove depencency of seqan3 io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,14 @@ The following API changes should be documented as such:
 
 If possible, provide tooling that performs the changes, e.g. a shell-script.
 -->
+
+## API changes
+
+#### I/O
+
+* In order to avoid using the seqan3 I/O module, you now have to give a list of file extensions explicitly to
+`sharg::input_file_validator` and `sharg::output_file_validator`:
+For example `sharg::input_file_validator validator{std::vector<std::string>{{"exe"}, {"fasta"}}};`. Please follow
+https://github.com/seqan/seqan3/issues/2927 to see how the list of file extensions can be extracted from seqan3 files.
+We also removed the `default_extensions()` function, as we now can construct `output_file_validator` with just a given
+mode: `output_file_validator(output_file_open_options const mode)`. The extensions will be an empty array in this case.

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <set>
+#include <variant>
 
 #include <sharg/detail/format_help.hpp>
 #include <sharg/detail/format_html.hpp>

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -17,7 +17,6 @@
 
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/debug_stream/range.hpp>
-#include <seqan3/io/detail/misc.hpp>
 
 #include <sharg/detail/safe_filesystem_entry.hpp>
 #include <sharg/exceptions.hpp>
@@ -262,7 +261,6 @@ value_list_validator(range_type && rng) -> value_list_validator<std::ranges::ran
 
 /*!\brief An abstract base class for the file and directory validators.
  * \ingroup argument_parser
- * \tparam file_t The type of the file to get the valid extensions for; `void` on default.
  *
  * \details
  *
@@ -458,7 +456,6 @@ protected:
 /*!\brief A validator that checks if a given path is a valid input file.
  * \ingroup argument_parser
  * \implements sharg::validator
- * \tparam file_t The type of the file to get the valid extensions for; `void` on default.
  *
  * \details
  *
@@ -469,9 +466,7 @@ protected:
  *
  * \include test/snippet/argument_parser/validators_input_file.cpp
  *
- * The valid extensions can also be obtained from a seqan3 formatted file type, e.g. sharg::sequence_input_file, if
- * it is given as template argument to this class. The following snippet demonstrates the different ways to instantiate
- * the sharg::input_file_validator.
+ * The following snippet demonstrates the different ways to instantiate the sharg::input_file_validator.
  *
  * \include test/snippet/argument_parser/validators_input_file_ext_from_file.cpp
  *
@@ -479,13 +474,9 @@ protected:
  *
  * \remark For a complete overview, take a look at \ref argument_parser
  */
-template <typename file_t = void>
 class input_file_validator : public file_validator_base
 {
 public:
-
-    static_assert(std::same_as<file_t, void> || seqan3::detail::has_type_valid_formats<file_t>,
-                  "Expected either a template type with a static member called valid_formats (a file type) or void.");
 
     // Import from base class.
     using typename file_validator_base::option_value_type;
@@ -494,22 +485,7 @@ public:
      * \{
      */
 
-    /*!\brief Default constructor.
-     *
-     * \details
-     *
-     * If the class' template argument `file_t` names a valid seqan3 file type that contains a
-     * static member `valid_formats`, e.g. seqan3::sequence_input_file::valid_formats, then it generates the
-     * list of valid extensions from this file. Otherwise the extensions list is empty.
-     */
-    input_file_validator()
-    {
-        if constexpr (!std::same_as<file_t, void>)
-            file_validator_base::extensions = seqan3::detail::valid_file_extensions<typename file_t::valid_formats>();
-
-        file_validator_base::extensions_str = create_extensions_str();
-    }
-
+    input_file_validator() = default;                                         //!< Defaulted.
     input_file_validator(input_file_validator const &) = default;             //!< Defaulted.
     input_file_validator(input_file_validator &&) = default;                  //!< Defaulted.
     input_file_validator & operator=(input_file_validator const &) = default; //!< Defaulted.
@@ -518,17 +494,8 @@ public:
 
     /*!\brief Constructs from a given collection of valid extensions.
      * \param[in] extensions The valid extensions to validate for.
-     *
-     * \details
-     *
-     * This constructor is only available if `file_t` does not name a valid seqan3 file type that contains a
-     * static member `valid_formats`.
      */
-    explicit input_file_validator(std::vector<std::string> extensions)
-    //!\cond
-        requires std::same_as<file_t, void>
-    //!\endcond
-        : file_validator_base{}
+    explicit input_file_validator(std::vector<std::string> extensions) : file_validator_base{}
     {
         file_validator_base::extensions = std::move(extensions);
         file_validator_base::extensions_str = create_extensions_str();
@@ -592,7 +559,6 @@ enum class output_file_open_options
 /*!\brief A validator that checks if a given path is a valid output file.
  * \ingroup argument_parser
  * \implements sharg::validator
- * \tparam file_t The type of the file to get the valid extensions for; `void` on default.
  *
  * \details
  *
@@ -607,9 +573,7 @@ enum class output_file_open_options
  *
  * \include test/snippet/argument_parser/validators_output_file.cpp
  *
- * The valid extensions can also be obtained from a seqan3 formatted file type, e.g. sharg::sequence_input_file, if
- * it is given as template argument to this class. The following snippet demonstrates the different ways to instantiate
- * the sharg::output_file_validator.
+ * The following snippet demonstrates the different ways to instantiate the sharg::output_file_validator.
  *
  * \include test/snippet/argument_parser/validators_output_file_ext_from_file.cpp
  *
@@ -617,12 +581,9 @@ enum class output_file_open_options
  *
  * \remark For a complete overview, take a look at \ref argument_parser
  */
-template <typename file_t = void>
 class output_file_validator : public file_validator_base
 {
 public:
-    static_assert(std::same_as<file_t, void> || seqan3::detail::has_type_valid_formats<file_t>,
-                "Expected either a template type with a static member called valid_formats (a file type) or void.");
 
     // Import from base class.
     using typename file_validator_base::option_value_type;
@@ -632,23 +593,20 @@ public:
      */
 
     //!\copydoc sharg::input_file_validator::input_file_validator()
-    output_file_validator() : output_file_validator{output_file_open_options::create_new}
-    {}
+    output_file_validator() : output_file_validator{output_file_open_options::create_new} {}
 
-    output_file_validator(output_file_validator const &) = default; //!< Defaulted.
-    output_file_validator(output_file_validator &&) = default; //!< Defaulted.
+    output_file_validator(output_file_validator const &) = default;             //!< Defaulted.
+    output_file_validator(output_file_validator &&) = default;                  //!< Defaulted.
     output_file_validator & operator=(output_file_validator const &) = default; //!< Defaulted.
-    output_file_validator & operator=(output_file_validator &&) = default; //!< Defaulted.
+    output_file_validator & operator=(output_file_validator &&) = default;      //!< Defaulted.
     virtual ~output_file_validator() = default; //!< Virtual Destructor.
 
     /*!\brief Constructs from a given overwrite mode and a list of valid extensions.
      * \param[in] mode A sharg::output_file_open_options indicating whether the validator throws if a file already
                        exists.
-     * \param[in] extensions The valid extensions to validate for. Defaults to
-     *                       sharg::output_file_validator::default_extensions.
+     * \param[in] extensions The valid extensions to validate for.
      */
-    explicit output_file_validator(output_file_open_options const mode,
-                                   std::vector<std::string> extensions = default_extensions())
+    explicit output_file_validator(output_file_open_options const mode, std::vector<std::string> extensions = {})
         : file_validator_base{}, mode{mode}
     {
         file_validator_base::extensions = std::move(extensions);
@@ -658,21 +616,6 @@ public:
     // Import base constructor.
     using file_validator_base::file_validator_base;
     //!\}
-
-    /*!\brief The default extensions of `file_t`.
-     * \returns A list of default extensions for `file_t`, will be empty if `file_t` is `void`.
-     *
-     * \details
-     *
-     * If `file_t` does name a valid seqan3 file type that contains a static member `valid_formats` returns the
-     * extensions of that `file_t` type. Otherwise returns an empty list.
-     */
-    static std::vector<std::string> default_extensions()
-    {
-        if constexpr (!std::same_as<file_t, void>)
-            return seqan3::detail::valid_file_extensions<typename file_t::valid_formats>();
-        return {};
-    }
 
     // Import the base::operator()
     using file_validator_base::operator();

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <seqan3/std/algorithm>
 #include <fstream>
 #include <regex>
 

--- a/test/snippet/validators_input_file_ext_from_file.cpp
+++ b/test/snippet/validators_input_file_ext_from_file.cpp
@@ -1,5 +1,3 @@
-#include <seqan3/io/sequence_file/input.hpp>
-
 #include <sharg/validators.hpp>
 
 int main()
@@ -11,10 +9,6 @@ int main()
     // Specify your own extensions for the input file.
     sharg::input_file_validator validator2{std::vector{std::string{"exe"}, std::string{"fasta"}}};
     std::cerr << validator2.get_help_page_message() << '\n';
-
-    // Give the seqan3 file type as a template argument to get all valid extensions for this file.
-    sharg::input_file_validator<seqan3::sequence_file_input<>> validator3{};
-    std::cerr << validator3.get_help_page_message() << '\n';
 
     return 0;
 }

--- a/test/snippet/validators_input_file_ext_from_file.err
+++ b/test/snippet/validators_input_file_ext_from_file.err
@@ -1,3 +1,2 @@
 The input file must exist and read permissions must be granted.
 The input file must exist and read permissions must be granted. Valid file extensions are: [exe, fasta].
-The input file must exist and read permissions must be granted. Valid file extensions are: [embl, fasta, fa, fna, ffn, faa, frn, fas, fastq, fq, genbank, gb, gbk, sam].

--- a/test/snippet/validators_output_file_ext_from_file.cpp
+++ b/test/snippet/validators_output_file_ext_from_file.cpp
@@ -1,5 +1,3 @@
-#include <seqan3/io/sequence_file/output.hpp>
-
 #include <sharg/validators.hpp>
 
 int main()
@@ -10,15 +8,8 @@ int main()
 
     // Specify your own extensions for the output file.
     sharg::output_file_validator validator2{sharg::output_file_open_options::create_new,
-                                             std::vector{std::string{"exe"}, std::string{"fasta"}}};
+                                            std::vector{std::string{"exe"}, std::string{"fasta"}}};
     std::cerr << validator2.get_help_page_message() << '\n';
-
-    // Give the seqan3 file type as a template argument to get all valid extensions for this file.
-    sharg::output_file_validator<seqan3::sequence_file_output<>> validator3
-    {
-        sharg::output_file_open_options::create_new
-    };
-    std::cerr << validator3.get_help_page_message() << '\n';
 
     return 0;
 }

--- a/test/snippet/validators_output_file_ext_from_file.err
+++ b/test/snippet/validators_output_file_ext_from_file.err
@@ -1,3 +1,2 @@
 The output file must not exist already and write permissions must be granted.
 The output file must not exist already and write permissions must be granted. Valid file extensions are: [exe, fasta].
-The output file must not exist already and write permissions must be granted. Valid file extensions are: [embl, fasta, fa, fna, ffn, faa, frn, fas, fastq, fq, genbank, gb, gbk, sam].

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -14,32 +14,29 @@
 struct dummy_file
 {
 
-    struct format1
+    struct format
     {
-        static inline std::vector<std::string> file_extensions{ {"fa"}, {"fasta"}};
+        static inline std::vector<std::string> file_extensions{ {"fa"}, {"fasta"}, {"sam"}, {"bam"}};
     };
 
-    struct format2
-    {
-        static inline std::vector<std::string> file_extensions{ {"sam"}, {"bam"}};
-    };
-
-    using valid_formats = seqan3::type_list<format1, format2>;
 };
 
+dummy_file::format f;
+std::vector<std::string> dummy_file_extensions = f.file_extensions;
+
 std::string const basic_options_str = "OPTIONS\n"
-                                     "\n"
-                                     "  Basic options:\n"
-                                     "    -h, --help\n"
-                                     "          Prints the help page.\n"
-                                     "    -hh, --advanced-help\n"
-                                     "          Prints the help page including advanced options.\n"
-                                     "    --version\n"
-                                     "          Prints the version information.\n"
-                                     "    --copyright\n"
-                                     "          Prints the copyright/license information.\n"
-                                     "    --export-help (std::string)\n"
-                                     "          Export the help page information. Value must be one of [html, man].\n";
+                                      "\n"
+                                      "  Basic options:\n"
+                                      "    -h, --help\n"
+                                      "          Prints the help page.\n"
+                                      "    -hh, --advanced-help\n"
+                                      "          Prints the help page including advanced options.\n"
+                                      "    --version\n"
+                                      "          Prints the version information.\n"
+                                      "    --copyright\n"
+                                      "          Prints the copyright/license information.\n"
+                                      "    --export-help (std::string)\n"
+                                      "          Export the help page information. Value must be one of [html, man].\n";
 
 std::string const basic_version_str = "VERSION\n"
                                       "    Last update:\n"
@@ -73,8 +70,8 @@ TEST(validator_test, fullfill_concept)
     EXPECT_TRUE(sharg::validator<sharg::arithmetic_range_validator<int>>);
     EXPECT_TRUE(sharg::validator<sharg::value_list_validator<double>>);
     EXPECT_TRUE(sharg::validator<sharg::value_list_validator<std::string>>);
-    EXPECT_TRUE(sharg::validator<sharg::input_file_validator<>>);
-    EXPECT_TRUE(sharg::validator<sharg::output_file_validator<>>);
+    EXPECT_TRUE(sharg::validator<sharg::input_file_validator>);
+    EXPECT_TRUE(sharg::validator<sharg::output_file_validator>);
     EXPECT_TRUE(sharg::validator<sharg::input_directory_validator>);
     EXPECT_TRUE(sharg::validator<sharg::output_directory_validator>);
     EXPECT_TRUE(sharg::validator<sharg::regex_validator>);
@@ -133,7 +130,7 @@ TEST(validator_test, input_file)
         }
 
         {  // read from file
-            sharg::input_file_validator<dummy_file> my_validator{};
+            sharg::input_file_validator my_validator{dummy_file_extensions};
             EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
         }
 
@@ -192,17 +189,6 @@ TEST(validator_test, input_file)
                                basic_version_str;
         EXPECT_EQ(my_stdout, expected);
     }
-}
-
-TEST(validator_test, input_file_ext_from_file)
-{
-    // Give as a template argument the seqan3 file type to get all valid extensions for this file.
-    sharg::input_file_validator<dummy_file> validator{};
-    EXPECT_EQ(validator.get_help_page_message(), "The input file must exist and read permissions must be granted. "
-                                                 "Valid file extensions are: [fa, fasta, sam, bam].");
-
-    sharg::input_file_validator validator2{};
-    EXPECT_EQ(validator2.get_help_page_message(), "The input file must exist and read permissions must be granted.");
 }
 
 TEST(validator_test, output_file)
@@ -264,8 +250,13 @@ TEST(validator_test, output_file)
         }
 
         {  // read from file
-            sharg::output_file_validator<dummy_file> my_validator{};
+            sharg::output_file_validator my_validator{sharg::output_file_open_options::create_new,
+                                                      dummy_file_extensions};
             EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
+
+            sharg::output_file_validator my_validator2{sharg::output_file_open_options::open_or_create,
+                                                       dummy_file_extensions};
+            EXPECT_NO_THROW(my_validator2(tmp_name.get_path()));
         }
 
         std::filesystem::path file_out_path;
@@ -355,33 +346,6 @@ TEST(validator_test, output_file)
                                basic_version_str;
         EXPECT_EQ(my_stdout, expected);
     }
-}
-
-TEST(validator_test, output_file_ext_from_file)
-{
-    // Give as a template argument the seqan3 file type to get all valid extensions for this file.
-    sharg::output_file_validator<dummy_file> validator1{};
-    EXPECT_EQ(validator1.get_help_page_message(), "The output file must not exist already and write permissions must "
-                                                  "be granted. Valid file extensions are: [fa, fasta, sam, bam].");
-
-    sharg::output_file_validator<dummy_file> validator2{sharg::output_file_open_options::create_new};
-    EXPECT_EQ(validator2.get_help_page_message(), "The output file must not exist already and write permissions must "
-                                                  "be granted. Valid file extensions are: [fa, fasta, sam, bam].");
-
-    sharg::output_file_validator<dummy_file> validator3{sharg::output_file_open_options::open_or_create};
-    EXPECT_EQ(validator3.get_help_page_message(), "Write permissions must be granted. Valid file extensions are: [fa, "
-                                                  "fasta, sam, bam].");
-
-    sharg::output_file_validator validator4{};
-    EXPECT_EQ(validator4.get_help_page_message(), "The output file must not exist already and write permissions must "
-                                                  "be granted.");
-
-    sharg::output_file_validator validator5{sharg::output_file_open_options::create_new};
-    EXPECT_EQ(validator5.get_help_page_message(), "The output file must not exist already and write permissions must "
-                                                  "be granted.");
-
-    sharg::output_file_validator validator6{sharg::output_file_open_options::open_or_create};
-    EXPECT_EQ(validator6.get_help_page_message(), "Write permissions must be granted.");
 }
 
 TEST(validator_test, input_directory)

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -11,19 +11,6 @@
 #include <sharg/test/file_access.hpp>
 #include <sharg/test/tmp_filename.hpp>
 
-struct dummy_file
-{
-
-    struct format
-    {
-        static inline std::vector<std::string> file_extensions{ {"fa"}, {"fasta"}, {"sam"}, {"bam"}};
-    };
-
-};
-
-dummy_file::format f;
-std::vector<std::string> dummy_file_extensions = f.file_extensions;
-
 std::string const basic_options_str = "OPTIONS\n"
                                       "\n"
                                       "  Basic options:\n"
@@ -129,11 +116,6 @@ TEST(validator_test, input_file)
             EXPECT_NO_THROW(my_validator(tmp_name_multiple.get_path()));
         }
 
-        {  // read from file
-            sharg::input_file_validator my_validator{dummy_file_extensions};
-            EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
-        }
-
         std::filesystem::path file_in_path;
 
         // option
@@ -188,6 +170,15 @@ TEST(validator_test, input_file)
                                "\n" +
                                basic_version_str;
         EXPECT_EQ(my_stdout, expected);
+    }
+
+    { // get help page message (file extensions)
+        sharg::input_file_validator validator1{formats};
+        EXPECT_EQ(validator1.get_help_page_message(), "The input file must exist and read permissions must be granted. "
+                                                      "Valid file extensions are: [fa, sam, fasta, fasta.txt].");
+
+        sharg::input_file_validator validator2{std::vector<std::string> {}};
+        EXPECT_EQ(validator2.get_help_page_message(), "The input file must exist and read permissions must be granted.");
     }
 }
 
@@ -247,16 +238,6 @@ TEST(validator_test, output_file)
             multiple_extension.replace_extension("fasta.txt");
             sharg::output_file_validator my_validator{sharg::output_file_open_options::create_new, formats};
             EXPECT_NO_THROW(my_validator(multiple_extension));
-        }
-
-        {  // read from file
-            sharg::output_file_validator my_validator{sharg::output_file_open_options::create_new,
-                                                      dummy_file_extensions};
-            EXPECT_NO_THROW(my_validator(tmp_name.get_path()));
-
-            sharg::output_file_validator my_validator2{sharg::output_file_open_options::open_or_create,
-                                                       dummy_file_extensions};
-            EXPECT_NO_THROW(my_validator2(tmp_name.get_path()));
         }
 
         std::filesystem::path file_out_path;
@@ -345,6 +326,17 @@ TEST(validator_test, output_file)
                                "\n" +
                                basic_version_str;
         EXPECT_EQ(my_stdout, expected);
+    }
+
+    { // get help page message (file extensions)
+        sharg::output_file_validator validator1{sharg::output_file_open_options::create_new, formats};
+        EXPECT_EQ(validator1.get_help_page_message(), "The output file must not exist already and write permissions "
+                                                      "must be granted. Valid file extensions are: "
+                                                      "[fa, sam, fasta, fasta.txt].");
+
+        sharg::output_file_validator validator2{sharg::output_file_open_options::create_new, std::vector<std::string> {}};
+        EXPECT_EQ(validator2.get_help_page_message(), "The output file must not exist already and write permissions "
+                                                      "must be granted.");
     }
 }
 


### PR DESCRIPTION
Resolves #42 

To avoid using seqan3::io we changed the usage of the `seqan3::input_file_validator` and `seqan3::output_file_validator`, you now have to give the formats explicitly:
`sharg::input_file_validator validator{std::vector{std::string{"exe"}, std::string{"fasta"}}};` and `sharg::output_file_validator validator{sharg::output_file_open_options::create_new, std::vector{std::string{"exe"}, std::string{"fasta"}}};`.

I also created a new issue seqan/seqan3#2927 for accessing valid formats from file.