### PR TITLE
[MISC] Remove dependency of seqan3::arithmetic by using std::is_arithmetic_v.

### DIFF
--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -385,7 +385,7 @@ private:
     }
 
     /*!\brief Tries to parse an input string into an arithmetic value.
-     * \tparam option_t The option value type; must model seqan3::arithmetic.
+     * \tparam option_t The option value type; must model std::is_arithmetic_v.
      * \param[out] value Stores the parsed value.
      * \param[in] in The input argument to be parsed.
      * \returns sharg::option_parse_result::error if `in` could not be parsed to an arithmetic type
@@ -396,9 +396,9 @@ private:
      *
      * This function delegates to std::from_chars.
      */
-    template <seqan3::arithmetic option_t>
+    template <typename option_t>
     //!\cond
-        requires seqan3::input_stream_over<std::istringstream, option_t>
+        requires std::is_arithmetic_v<option_t> && seqan3::input_stream_over<std::istringstream, option_t>
     //!\endcond
     option_parse_result parse_option_value(option_t & value, std::string const & in)
     {
@@ -458,7 +458,7 @@ private:
                                    get_type_name_as_string(option_type{}) + "."};
         }
 
-        if constexpr (seqan3::arithmetic<option_type>)
+        if constexpr (std::is_arithmetic_v<option_type>)
         {
             if (res == option_parse_result::overflow_error)
             {

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -57,7 +57,7 @@ concept validator = std::copyable<std::remove_cvref_t<validator_type>> &&
 /*!\brief A validator that checks whether a number is inside a given range.
  * \ingroup argument_parser
  * \implements sharg::validator
- * \tparam option_value_t The value type of the range; must model seqan3::arithmetic .
+ * \tparam option_value_t The value type of the range; must model std::is_arithmetic_v.
  *
  * \details
  *
@@ -69,7 +69,10 @@ concept validator = std::copyable<std::remove_cvref_t<validator_type>> &&
  *
  * \remark For a complete overview, take a look at \ref argument_parser
  */
-template <seqan3::arithmetic option_value_t>
+template <typename option_value_t>
+//!\cond
+    requires std::is_arithmetic_v<option_value_t>
+//!\endcond
 class arithmetic_range_validator
 {
 public:
@@ -96,13 +99,13 @@ public:
 
     /*!\brief Tests whether every element in \p range lies inside [`min`, `max`].
      * \tparam range_type The type of range to check; must model std::ranges::forward_range. The value type must model
-     *                    seqan3::arithmetic.
+     *                    std::is_arithmetic_v.
      * \param  range      The input range to iterate over and check every element.
      * \throws sharg::validation_error
      */
     template <std::ranges::forward_range range_type>
     //!\cond
-        requires seqan3::arithmetic<std::ranges::range_value_t<range_type>>
+        requires std::is_arithmetic_v<std::ranges::range_value_t<range_type>>
     //!\endcond
     void operator()(range_type const & range) const
     {


### PR DESCRIPTION
Came up when working on #41.

Simply replaces the `seqan3::arithmetic` by the metafunction `std::is_arithmetic_v`