### PR TITLE
[MISC] Remove dependency on ranges::move and cpp20::back_inserter.

### DIFF
--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -174,7 +174,8 @@ public:
     value_list_validator(range_type rng)
     {
         values.clear();
-        std::ranges::move(std::move(rng), std::cpp20::back_inserter(values));
+        for (auto & val : rng)
+            values.push_back(std::move(val));
     }
 
     /*!\brief Constructing from a parameter pack.

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -174,8 +174,7 @@ public:
     value_list_validator(range_type rng)
     {
         values.clear();
-        for (auto & val : rng)
-            values.push_back(std::move(val));
+    std::move(rng.begin(), rng.end(), std::back_inserter(values));
     }
 
     /*!\brief Constructing from a parameter pack.

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -174,7 +174,7 @@ public:
     value_list_validator(range_type rng)
     {
         values.clear();
-    std::move(rng.begin(), rng.end(), std::back_inserter(values));
+        std::move(rng.begin(), rng.end(), std::back_inserter(values));
     }
 
     /*!\brief Constructing from a parameter pack.


### PR DESCRIPTION
Follow up of #44 