### PR TITLE
[FEATURE] Add sharg::istreamable concept.

### DIFF
--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -17,7 +17,6 @@
 
 #include <seqan3/core/debug_stream/debug_stream_type.hpp>
 #include <seqan3/core/detail/customisation_point.hpp>
-#include <seqan3/io/stream/concept.hpp>
 
 #include <sharg/platform.hpp>
 

--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -186,24 +186,6 @@ concept named_enumeration = requires
     { sharg::enumeration_names<option_type> };
 };
 
-/*!\concept sharg::argument_parser_compatible_option
- * \brief Checks whether the the type can be used in an add_(positional_)option call on the argument parser.
- * \ingroup argument_parser
- * \tparam option_type The type to check.
- *
- * ### Requirements
- *
- * In order to model this concept, the type must either be streamable to std::istringstream or
- * model sharg::named_enumeration<option_type>.
- *
- * \remark For a complete overview, take a look at \ref argument_parser
- */
-template <typename option_type>
-concept argument_parser_compatible_option = seqan3::input_stream_over<std::istringstream, option_type> ||
-                                            named_enumeration<option_type>;
-
-
-
 /*!\brief Used to further specify argument_parser options/flags.
  * \ingroup argument_parser
  *

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -31,7 +31,7 @@ namespace sharg
 template <typename value_type>
 concept istreamable = requires (std::istream & is, value_type & val)
 {
-    { is >> val };
+    SHARG_RETURN_TYPE_CONSTRAINT(is >> val, std::is_same_v, std::istream&);
 };
 
 /*!\concept sharg::argument_parser_compatible_option

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -47,7 +47,6 @@ concept istreamable = requires (std::istream & is, value_type & val)
  * \remark For a complete overview, take a look at \ref argument_parser
  */
 template <typename option_type>
-concept argument_parser_compatible_option = seqan3::input_stream_over<std::istringstream, option_type> ||
-                                            named_enumeration<option_type>;
+concept argument_parser_compatible_option = sharg::istreamable<option_type> || named_enumeration<option_type>;
 
 } // namespace sharg

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
+ * \brief Provides helper concepts.
+ */
+
+#pragma once
+
+#include <sharg/auxiliary.hpp>
+
+namespace sharg
+{
+
+/*!\concept sharg::istreamable
+ * \ingroup argument_parser
+ * \brief Concept for types that can be parsed from a std::istream via the stream operator.
+ * \tparam value_type The type to check whether it's stremable via std::istream.
+ *
+ * ### Requirements
+ *
+ * `std::istream` must support the (un)formatted input function (`operator>>`) for an l-value of a given `value_type`.
+ *
+ * todo: link to how-to page how to make your type istreamable
+ */
+template <typename value_type>
+concept istreamable = requires (std::istream & is, value_type & val)
+{
+    { is >> val };
+};
+
+/*!\concept sharg::argument_parser_compatible_option
+ * \brief Checks whether the the type can be used in an add_(positional_)option call on the argument parser.
+ * \ingroup argument_parser
+ * \tparam option_type The type to check.
+ *
+ * ### Requirements
+ *
+ * In order to model this concept, the type must either model sharg::istreamable and sharg::ostreamable or
+ * model sharg::named_enumeration<option_type>.
+ *
+ * \remark For a complete overview, take a look at \ref argument_parser
+ */
+template <typename option_type>
+concept argument_parser_compatible_option = seqan3::input_stream_over<std::istringstream, option_type> ||
+                                            named_enumeration<option_type>;
+
+} // namespace sharg

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <seqan3/std/concepts>
+
 #include <sharg/auxiliary.hpp>
 
 namespace sharg

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -27,8 +27,6 @@ namespace sharg
  * ### Requirements
  *
  * `std::istream` must support the (un)formatted input function (`operator>>`) for an l-value of a given `value_type`.
- *
- * todo: link to how-to page how to make your type istreamable
  */
 template <typename value_type>
 concept istreamable = requires (std::istream & is, value_type & val)

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -31,7 +31,7 @@ namespace sharg
 template <typename value_type>
 concept istreamable = requires (std::istream & is, value_type & val)
 {
-    SHARG_RETURN_TYPE_CONSTRAINT(is >> val, std::is_same_v, std::istream&);
+    SHARG_RETURN_TYPE_CONSTRAINT(is >> val, std::same_as, std::istream&);
 };
 
 /*!\concept sharg::argument_parser_compatible_option

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -15,6 +15,7 @@
 #include <sharg/std/charconv>
 
 #include <sharg/detail/format_base.hpp>
+#include <sharg/concept.hpp>
 
 namespace sharg::detail
 {

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -285,7 +285,7 @@ private:
     }
 
     /*!\brief Tries to parse an input string into a value using the stream `operator>>`.
-     * \tparam option_t Must model seqan3::input_stream_over.
+     * \tparam option_t Must model sharg::istreamable.
      * \param[out] value Stores the parsed value.
      * \param[in] in The input argument to be parsed.
      * \returns sharg::option_parse_result::error if `in` could not be parsed via the stream
@@ -293,7 +293,7 @@ private:
      */
     template <typename option_t>
     //!\cond
-        requires seqan3::input_stream_over<std::istringstream, option_t>
+        requires istreamable<option_t>
     //!\endcond
     option_parse_result parse_option_value(option_t & value, std::string const & in)
     {
@@ -408,7 +408,7 @@ private:
      */
     template <typename option_t>
     //!\cond
-        requires std::is_arithmetic_v<option_t> && seqan3::input_stream_over<std::istringstream, option_t>
+        requires std::is_arithmetic_v<option_t> && istreamable<option_t>
     //!\endcond
     option_parse_result parse_option_value(option_t & value, std::string const & in)
     {


### PR DESCRIPTION
Came up when working on #41 

This replaces the need of `seqan3::input_stream_over`. Since we always use `std::istringstream` I made the concept explicit.

Name is up for discussion.