### PR TITLE
[MISC] Remove std::ranges::copy and std::cpp20::back_inserter.

### DIFF
--- a/doc/tutorial/argument_parser/solution3.cpp
+++ b/doc/tutorial/argument_parser/solution3.cpp
@@ -7,9 +7,8 @@
 template <typename number_type, typename range_type>
 number_type to_number(range_type && range)
 {
-    std::string str;
+    std::string str = [&range] () { std::string s; for (auto c : range) s.push_back(c); return s; }();
     number_type num;
-    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/doc/tutorial/argument_parser/solution4.cpp
+++ b/doc/tutorial/argument_parser/solution4.cpp
@@ -6,9 +6,8 @@
 template <typename number_type, typename range_type>
 number_type to_number(range_type && range)
 {
-    std::string str;
+    std::string str = [&range] () { std::string s; for (auto c : range) s.push_back(c); return s; }();
     number_type num;
-    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/doc/tutorial/argument_parser/solution5.cpp
+++ b/doc/tutorial/argument_parser/solution5.cpp
@@ -6,9 +6,8 @@
 template <typename number_type, typename range_type>
 number_type to_number(range_type && range)
 {
-    std::string str;
+    std::string str = [&range] () { std::string s; for (auto c : range) s.push_back(c); return s; }();
     number_type num;
-    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/doc/tutorial/argument_parser/solution6.cpp
+++ b/doc/tutorial/argument_parser/solution6.cpp
@@ -6,9 +6,8 @@
 template <typename number_type, typename range_type>
 number_type to_number(range_type && range)
 {
-    std::string str;
+    std::string str = [&range] () { std::string s; for (auto c : range) s.push_back(c); return s; }();
     number_type num;
-    std::ranges::copy(range, std::cpp20::back_inserter(str));
     auto res = std::from_chars(&str[0], &str[0] + str.size(), num);
 
     if (res.ec != std::errc{})

--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -697,7 +697,7 @@ private:
         {
             std::string arg{argv[i]};
 
-            if (std::ranges::find(subcommands, arg) != subcommands.end())
+            if (std::find(subcommands.begin(), subcommands.end(), arg) != subcommands.end())
             {
                 sub_parser = std::make_unique<argument_parser>(info.app_name + "-" + arg,
                                                                argc - i,

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -317,17 +317,14 @@ protected:
 
         // Tokenize the text.
         std::istringstream iss(text.c_str());
-        std::vector<std::string> tokens;
-        std::ranges::copy(std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>(),
-                          std::cpp20::back_inserter(tokens));
+        std::vector<std::string> tokens{std::istream_iterator<std::string>(iss), std::istream_iterator<std::string>()};
 
         // Print the text.
         assert(pos <= tab);
         std::fill_n(out, tab - pos, ' ');  // go to tab
 
         pos = tab;
-        typedef std::vector<std::string>::const_iterator TConstIter;
-        for (TConstIter it = tokens.begin(); it != tokens.end(); ++it)
+        for (auto it = tokens.begin(); it != tokens.end(); ++it)
         {
             if (it == tokens.begin())
             {

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <seqan3/std/algorithm>
 #include <fstream>
 #include <regex>
 
@@ -355,7 +354,7 @@ protected:
         };
 
         // Check if requested extension is present.
-        if (std::ranges::find_if(extensions, case_insensitive_ends_with) == extensions.end())
+        if (std::find_if(extensions.begin(), extensions.end(), case_insensitive_ends_with) == extensions.end())
         {
             throw validation_error{"Expected one of the following valid extensions: " + extensions_str + "! Got " +
                                     all_extensions + " instead!"};
@@ -429,12 +428,15 @@ protected:
     {
         size_t const suffix_length{suffix.size()};
         size_t const str_length{str.size()};
-        return suffix_length > str_length ?
-               false :
-               std::ranges::equal(str.substr(str_length - suffix_length), suffix, [] (char const chr1, char const chr2)
-               {
-                   return std::tolower(chr1) == std::tolower(chr2);
-               });
+
+        if (suffix_length > str_length)
+            return false;
+
+        for (size_t j = 0, s_start = str_length - suffix_length; j < suffix_length; ++j)
+            if (std::tolower(str[s_start + j]) != std::tolower(suffix[j]))
+                return false;
+
+        return true;
     }
 
     //!\brief Creates a std::string from the extensions list, e.g. "[ext, ext2]".

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -228,6 +228,13 @@ TEST(validator_test, output_file)
             EXPECT_THROW(my_validator(no_extension), sharg::validation_error);
         }
 
+        { // filename is shorter than extension.
+            std::filesystem::path filename{tmp_name.get_path()};
+            std::vector<std::string> long_extension{"super_duper_long_extension_longer_than_seqan_tmp_filename"};
+            sharg::output_file_validator my_validator{sharg::output_file_open_options::create_new, long_extension};
+            EXPECT_THROW(my_validator(filename), sharg::validation_error);
+        }
+
         { // filename starts with dot.
             sharg::output_file_validator my_validator{sharg::output_file_open_options::create_new, formats};
             EXPECT_NO_THROW(my_validator(hidden_name.get_path()));


### PR DESCRIPTION
Follow up of #44 

Most changes are euqivalent because we don't need e.g. `std::ranges::find` if we have a common range anyway. IMHO [this change](https://github.com/seqan/sharg-parser/pull/54/files#diff-4e3decd5363eace7fcffe5b6a3896159daabf014500f352ae66d10be4194991cL432) even became more readable. 

The only not nice change is this one
```diff
+    std::string str = [&range] () { std::string s; for (auto c : range) s.push_back(c); return s; }();
-    std::string str;
-    std::ranges::copy(range, std::cpp20::back_inserter(str));
```

because it is in the snippets and thus code that is exposed to the user.
We might want to think about adding the std/ranges module to the sharg parser or drop gcc-9 support which would make `#include <ranges>` available directly. Then we can change this back.