### PR TITLE
[DOC] Add howto on custom types.

### DIFF
--- a/doc/howto/custom_types/custom_type.cpp
+++ b/doc/howto/custom_types/custom_type.cpp
@@ -1,0 +1,49 @@
+#include <sharg/all.hpp>
+
+// my custom type
+namespace foo
+{
+
+class bar
+{
+public:
+    int a;
+
+    // Make foo::bar model sharg::ostreamable
+    friend std::ostream &operator<<( std::ostream & output, const bar & foob)
+    {
+        output << foob.a; // this needs to be adapted to suit your type
+        return output;
+    }
+
+    // Make foo::bar model sharg::istreamable
+    friend std::istream &operator>>( std::istream & input, bar & foob)
+    {
+        input >> foob.a;  // this needs to be adapted to suit your type
+        return input;
+    }
+};
+
+} // namespace foo
+
+int main(int argc, char const ** argv)
+{
+    sharg::argument_parser parser{"my_foobar_parser", argc, argv, sharg::update_notifications::off};
+
+    foo::bar foob{};
+    parser.add_option(foob, 'f', "foo-bar", "Please supply an integer for member foo::bar::a");
+
+    try
+    {
+        parser.parse(); // trigger command line parsing
+    }
+    catch (sharg::argument_parser_error const & ext) // catch user errors
+    {
+        std::cerr << "[Error] " << ext.what() << "\n"; // customise your error message
+        return -1;
+    }
+
+    std::cout << "foob was initialised with a = " << foob.a << std::endl;
+
+    return 0;
+}

--- a/doc/howto/custom_types/custom_type.cpp
+++ b/doc/howto/custom_types/custom_type.cpp
@@ -9,17 +9,17 @@ class bar
 public:
     int a;
 
-    // Make foo::bar model sharg::ostreamable
-    friend std::ostream &operator<<( std::ostream & output, const bar & foob)
+    // Make foo::bar satisfy sharg::ostreamable
+    friend std::ostream & operator<<(std::ostream & output, const bar & my_bar)
     {
-        output << foob.a; // this needs to be adapted to suit your type
+        output << my_bar.a; // Adapt this for your type
         return output;
     }
 
-    // Make foo::bar model sharg::istreamable
-    friend std::istream &operator>>( std::istream & input, bar & foob)
+    // Make foo::bar satisfy sharg::istreamable
+    friend std::istream & operator>>(std::istream & input, bar & my_bar)
     {
-        input >> foob.a;  // this needs to be adapted to suit your type
+        input >> my_bar.a;  // Adapt this for your type
         return input;
     }
 };
@@ -30,8 +30,8 @@ int main(int argc, char const ** argv)
 {
     sharg::argument_parser parser{"my_foobar_parser", argc, argv, sharg::update_notifications::off};
 
-    foo::bar foob{};
-    parser.add_option(foob, 'f', "foo-bar", "Please supply an integer for member foo::bar::a");
+    foo::bar my_bar{};
+    parser.add_option(my_bar, 'f', "foo-bar", "Please supply an integer for member foo::bar::a");
 
     try
     {
@@ -43,7 +43,7 @@ int main(int argc, char const ** argv)
         return -1;
     }
 
-    std::cout << "foob was initialised with a = " << foob.a << std::endl;
+    std::cout << "my_bar was initialised with a = " << my_bar.a << std::endl;
 
     return 0;
 }

--- a/doc/howto/custom_types/custom_type.out
+++ b/doc/howto/custom_types/custom_type.out
@@ -1,0 +1,3 @@
+my_foobar_parser
+================
+    Try -h or --help for more information.

--- a/doc/howto/custom_types/external_custom_type.cpp
+++ b/doc/howto/custom_types/external_custom_type.cpp
@@ -1,29 +1,31 @@
 #include <sharg/all.hpp>
 
-// external type
+// external type, i.e., you cannot change the implementation
 namespace external
 {
+
 class bar
 {
 public:
     int a;
 };
+
 } // namespace external
 
 namespace std
 {
 
-// Make external::bar model sharg::ostreamable
+// Make external::bar satisfy sharg::ostreamable
 ostream & operator<<(ostream & output, const external::bar & ext_bar)
 {
-    output << ext_bar.a; // this needs to be adapted to suit your type
+    output << ext_bar.a; // Adapt this for your type
     return output;
 }
 
-// Make external::bar model sharg::istreamable
+// Make external::bar satisfy sharg::istreamable
 istream & operator>>(istream & input, external::bar & ext_bar)
 {
-    input >> ext_bar.a;  // this needs to be adapted to suit your type
+    input >> ext_bar.a;  // Adapt this for your type
     return input;
 }
 

--- a/doc/howto/custom_types/external_custom_type.cpp
+++ b/doc/howto/custom_types/external_custom_type.cpp
@@ -1,0 +1,52 @@
+#include <sharg/all.hpp>
+
+// external type
+namespace external
+{
+class bar
+{
+public:
+    int a;
+};
+} // namespace external
+
+namespace std
+{
+
+// Make external::bar model sharg::ostreamable
+ostream & operator<<(ostream & output, const external::bar & ext_bar)
+{
+    output << ext_bar.a; // this needs to be adapted to suit your type
+    return output;
+}
+
+// Make external::bar model sharg::istreamable
+istream & operator>>(istream & input, external::bar & ext_bar)
+{
+    input >> ext_bar.a;  // this needs to be adapted to suit your type
+    return input;
+}
+
+} // namespace std
+
+int main(int argc, char const ** argv)
+{
+    sharg::argument_parser parser{"my_ext_bar_parser", argc, argv, sharg::update_notifications::off};
+
+    external::bar ext_bar{};
+    parser.add_option(ext_bar, 'f', "external-bar", "Please supply an integer for member external::bar::a");
+
+    try
+    {
+        parser.parse(); // trigger command line parsing
+    }
+    catch (sharg::argument_parser_error const & ext) // catch user errors
+    {
+        std::cerr << "[Error] " << ext.what() << "\n"; // customise your error message
+        return -1;
+    }
+
+    std::cout << "ext_bar was initialised with a = " << ext_bar.a << std::endl;
+
+    return 0;
+}

--- a/doc/howto/custom_types/external_custom_type.out
+++ b/doc/howto/custom_types/external_custom_type.out
@@ -1,0 +1,3 @@
+my_ext_bar_parser
+=================
+    Try -h or --help for more information.

--- a/doc/howto/custom_types/index.md
+++ b/doc/howto/custom_types/index.md
@@ -1,0 +1,41 @@
+# How to make your custom type model harg::argument_parser_compatible_option {#fulfil_argument_parser_compatible_option}
+
+[TOC]
+
+This HowTo shows how make your custom type fulfil sharg::argument_parser_compatible_option.
+
+\tutorial_head{Easy, 10 min, , }
+
+# Motivation
+
+In order to use a custom type in an `sharg::argument_parser::add_option` or
+`sharg::argument_parser::add_positional_option` call, the type must model `sharg::argument_parser_compatible_option`.
+This tutorial will quickly show you what requirements must be met and will supply you with a copy and paste source
+for your code.
+
+# Concept sharg::argument_parser_compatible_option
+
+As you can see in the API documentation of `sharg::argument_parser_compatible_option`, the type must model either
+`sharg::istreamable` and `sharg::ostreamable` or `sharg::named_enumeration`.
+
+**If your type is an enum, take a look at `sharg::enumeration_names` to make it compatabile with the
+`sharg::argument_parser`.**
+
+Otherwise, your type needs to model `sharg::istreamable` and `sharg::ostreamable`.
+If you take a look at the concept in the documentation, you can see that the concept is simple. You merely need to
+overload the stream operators `operator>>()` and `operator<<()` for your type and `std::istream`/`std::ostream`
+respectively.
+
+# Make your own type compatible
+
+\note You must be able to modify the class itself for this solution to work.
+
+The following example makes the class `bar` in namespace `foo` compatible with the `sharg::argument_parser`:
+
+\include doc/howto/custom_types/custom_type.cpp
+
+# Make an external type compatible
+
+If you cannot modify the class you'd like to be compatible with the `sharg::parser`, you can do the following:
+
+\include doc/howto/custom_types/external_custom_type.cpp

--- a/doc/howto/custom_types/index.md
+++ b/doc/howto/custom_types/index.md
@@ -2,29 +2,28 @@
 
 [TOC]
 
-This HowTo shows how make your custom type fulfil sharg::argument_parser_compatible_option.
+This HowTo guides you through satisfying the requirements of sharg::argument_parser_compatible_option.
 
 \tutorial_head{Easy, 10 min, , }
 
 # Motivation
 
-In order to use a custom type in an `sharg::argument_parser::add_option` or
-`sharg::argument_parser::add_positional_option` call, the type must model `sharg::argument_parser_compatible_option`.
-This tutorial will quickly show you what requirements must be met and will supply you with a copy and paste source
+To use a custom type with `sharg::argument_parser::add_option` or
+`sharg::argument_parser::add_positional_option`, the type must satisfy `sharg::argument_parser_compatible_option`.
+This tutorial shows you what requirements must be met and supplies you with a copy and paste source
 for your code.
 
 # Concept sharg::argument_parser_compatible_option
 
-As you can see in the API documentation of `sharg::argument_parser_compatible_option`, the type must model either
+As you can see in the API documentation of `sharg::argument_parser_compatible_option`, the type must model either both
 `sharg::istreamable` and `sharg::ostreamable` or `sharg::named_enumeration`.
 
-**If your type is an enum, take a look at `sharg::enumeration_names` to make it compatabile with the
+**If your type is an enum, refer to `sharg::enumeration_names` on how to make it compatible with the
 `sharg::argument_parser`.**
 
-Otherwise, your type needs to model `sharg::istreamable` and `sharg::ostreamable`.
-If you take a look at the concept in the documentation, you can see that the concept is simple. You merely need to
-overload the stream operators `operator>>()` and `operator<<()` for your type and `std::istream`/`std::ostream`
-respectively.
+In all other cases, your type needs to model `sharg::istreamable` and `sharg::ostreamable`.
+As you can see in the respective documentation, the concept is simple. You merely need to
+supply the stream operators `operator>>()` and `operator<<()` for your type.
 
 # Make your own type compatible
 
@@ -36,6 +35,6 @@ The following example makes the class `bar` in namespace `foo` compatible with t
 
 # Make an external type compatible
 
-If you cannot modify the class you'd like to be compatible with the `sharg::parser`, you can do the following:
+If you cannot modify the class, you can do the following:
 
 \include doc/howto/custom_types/external_custom_type.cpp

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -24,6 +24,10 @@ namespace sharg
  * \brief Concept for types that can be parsed from a std::istream via the stream operator.
  * \tparam value_type The type to check whether it's stremable via std::istream.
  *
+ * Read up on how to make a type model this concept here:
+ *
+ * \ref fulfil_argument_parser_compatible_option.
+ *
  * ### Requirements
  *
  * `std::istream` must support the (un)formatted input function (`operator>>`) for an l-value of a given `value_type`.
@@ -38,6 +42,10 @@ concept istreamable = requires (std::istream & is, value_type & val)
  * \ingroup argument_parser
  * \brief Concept for types that can be parsed into a std::ostream via the stream operator.
  * \tparam type The type to check whether it's stremable via std::ostream or it's a container over streamable values.
+ *
+ * Read up on how to make a type model this concept here:
+ *
+ * \ref fulfil_argument_parser_compatible_option.
  *
  * ### Requirements
  *
@@ -58,6 +66,10 @@ requires (std::ostream & os, type & con)
  * \brief Checks whether the the type can be used in an add_(positional_)option call on the argument parser.
  * \ingroup argument_parser
  * \tparam option_type The type to check.
+ *
+ * Read up on how to make a type model this concept here:
+ *
+ * \ref fulfil_argument_parser_compatible_option.
  *
  * ### Requirements
  *

--- a/test/documentation/DoxygenLayout.xml
+++ b/test/documentation/DoxygenLayout.xml
@@ -13,6 +13,7 @@
     </tab>
       <tab type="usergroup" visible="yes" title="How-To" intro="">
       <tab type="user" visible="yes" title="Subcommand argument parsing" url="\ref subcommand_arg_parse" intro=""/>
+      <tab type="user" visible="yes" title="Make custom types comptabile" url="\ref fulfil_argument_parser_compatible_option" intro=""/>
     </tab>
     <tab type="user" visible="yes" title="Cookbook" url="\ref cookbook" intro=""/>
     <tab type="usergroup" visible="yes" title="About" intro="">


### PR DESCRIPTION
After requiring ostreamable for custom types #52, we should have a proper HowTo section on it.

Fixes #41 
