### PR TITLE
[MISC] Add new output_file_validator ctors

### DIFF
--- a/test/snippet/validators_output_file.cpp
+++ b/test/snippet/validators_output_file.cpp
@@ -13,9 +13,11 @@ int main(int argc, const char ** argv)
                         sharg::output_file_validator{sharg::output_file_open_options::open_or_create, {"fa","fasta"}});
 
     // ... or that you will throw a sharg::validation_error if the user specified output file already exists
+    // No sharg::output_file_open_options is passed: The default sharg::output_file_open_options::create_new is used.
+    // Possible extensions can also be passed as separate arguments.
     myparser.add_option(myfile, 'g', "file2", "Output file containing the processed sequences.",
                         sharg::option_spec::standard,
-                        sharg::output_file_validator{sharg::output_file_open_options::create_new, {"fa","fasta"}});
+                        sharg::output_file_validator{"fa","fasta"});
     //! [validator_call]
 
     // an exception will be thrown if the user specifies a filename

--- a/test/snippet/validators_output_file_ext_from_file.cpp
+++ b/test/snippet/validators_output_file_ext_from_file.cpp
@@ -5,13 +5,21 @@
 int main()
 {
     // Default constructed validator has an empty extension list.
-    sharg::output_file_validator validator1{sharg::output_file_open_options::create_new};
+    sharg::output_file_validator validator1{};
     std::cerr << validator1.get_help_page_message() << '\n';
 
     // Specify your own extensions for the output file.
     sharg::output_file_validator validator2{sharg::output_file_open_options::create_new,
                                             std::vector{std::string{"exe"}, std::string{"fasta"}}};
     std::cerr << validator2.get_help_page_message() << '\n';
+
+    // If you do not pass the output_file_open_options, the default of create_new is used.
+    sharg::output_file_validator validator3{std::vector{std::string{"exe"}, std::string{"fasta"}}};
+    std::cerr << validator3.get_help_page_message() << '\n';
+
+    // Instead of passing a std::vector<std::string>, you can also pass each extension as separate argument.
+    sharg::output_file_validator validator4{"exe", "fasta"};
+    std::cerr << validator4.get_help_page_message() << '\n';
 
     return 0;
 }

--- a/test/snippet/validators_output_file_ext_from_file.err
+++ b/test/snippet/validators_output_file_ext_from_file.err
@@ -1,2 +1,4 @@
 The output file must not exist already and write permissions must be granted.
 The output file must not exist already and write permissions must be granted. Valid file extensions are: [exe, fasta].
+The output file must not exist already and write permissions must be granted. Valid file extensions are: [exe, fasta].
+The output file must not exist already and write permissions must be granted. Valid file extensions are: [exe, fasta].

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -205,6 +205,10 @@ TEST(validator_test, output_file)
             EXPECT_NO_THROW(my_validator2(not_existing_path));
             sharg::output_file_validator my_validator3{}; // default: create_new
             EXPECT_NO_THROW(my_validator3(not_existing_path));
+            sharg::output_file_validator my_validator4{std::vector<std::string>{}}; // empty formats -> no formats
+            EXPECT_NO_THROW(my_validator4(not_existing_path));
+            sharg::output_file_validator my_validator5{""}; // empty formats -> no formats
+            EXPECT_NO_THROW(my_validator5(not_existing_path));
         }
 
         { // file does exist & overwriting is prohibited
@@ -346,6 +350,21 @@ TEST(validator_test, output_file)
         sharg::output_file_validator validator2{sharg::output_file_open_options::create_new, std::vector<std::string> {}};
         EXPECT_EQ(validator2.get_help_page_message(), "The output file must not exist already and write permissions "
                                                       "must be granted.");
+    }
+
+    { // parameter pack constructor - extensions only
+        sharg::output_file_validator validator1{"fa", "sam", "fasta", "fasta.txt"};
+        sharg::output_file_validator validator2{formats};
+        sharg::output_file_validator validator3{sharg::output_file_open_options::create_new, formats};
+        EXPECT_EQ(validator1.get_help_page_message(), validator2.get_help_page_message());
+        EXPECT_EQ(validator2.get_help_page_message(), validator3.get_help_page_message());
+    }
+
+    { // parameter pack constructor - mode + extensions
+        sharg::output_file_validator validator1{sharg::output_file_open_options::open_or_create,
+                                                "fa", "sam", "fasta", "fasta.txt"};
+        sharg::output_file_validator validator2{sharg::output_file_open_options::open_or_create, formats};
+        EXPECT_EQ(validator1.get_help_page_message(), validator2.get_help_page_message());
     }
 }
 


### PR DESCRIPTION
Open:
  - [x] We probably want some check (`static_assert`) for construction the vector from the parameter pack:
    - We need `requires` as it's important for overload resultion. 
  - [x] More/different documentation?