### PR TITLE
[INFRA] Use explicit header guard to avoid ambigiutity.

### DIFF
--- a/include/sharg/std/charconv
+++ b/include/sharg/std/charconv
@@ -11,7 +11,8 @@
  * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
  */
 
-#pragma once
+#ifndef SEQAN_CHARCONV_SHIM // to avoid multiple definitions if other seqan modules also implement this
+#define SEQAN_CHARCONV_SHIM
 
 #include <charconv>
 #include <utility> // __cpp_lib_to_chars may be defined here as currently documented.
@@ -274,3 +275,5 @@ using ::sharg::contrib::charconv_float::from_chars; // import our shim-float ver
 } // namespace std
 
 #endif // __cpp_lib_to_chars < 201611
+
+#endif // SEQAN_CHARCONV_SHIM


### PR DESCRIPTION
When sharg is backported to seqan3 and some cpp
includes sharg and seqan std/charconv, the overloads
are ambiguous. Adding explicit header guards of the
exact same name in both, resolves this.