### PR TITLE
[MISC] Simplify the detail::default_validator.

### DIFF
--- a/include/sharg/argument_parser.hpp
+++ b/include/sharg/argument_parser.hpp
@@ -238,7 +238,7 @@ public:
      *
      * \throws sharg::design_error
      */
-    template <typename option_type, validator validator_type = detail::default_validator<option_type>>
+    template <typename option_type, validator validator_type = detail::default_validator>
     //!\cond
         requires (argument_parser_compatible_option<option_type> ||
                   argument_parser_compatible_option<std::ranges::range_value_t<option_type>>) &&
@@ -307,7 +307,7 @@ public:
      *
      * The validator must be applicable to the given output variable (\p value).
      */
-    template <typename option_type, validator validator_type = detail::default_validator<option_type>>
+    template <typename option_type, validator validator_type = detail::default_validator>
     //!\cond
         requires (argument_parser_compatible_option<option_type> ||
                   argument_parser_compatible_option<std::ranges::range_value_t<option_type>>) &&

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include <any>
 #include <concepts>
 #include <fstream>
 #include <ranges>
@@ -929,7 +930,6 @@ namespace detail
 /*!\brief Validator that always returns true.
  * \ingroup argument_parser
  * \implements sharg::validator
- * \tparam option_value_t Must be a (container of) arithmetic type(s).
  *
  * \details
  *
@@ -938,13 +938,13 @@ namespace detail
  *
  * \remark For a complete overview, take a look at \ref argument_parser
  */
-template <typename option_value_t>
 struct default_validator
 {
-    //!\brief Type of values that are tested by validator
-    using option_value_type = option_value_t;
+    //!\brief Dummy type needed to model sharg::validator but any type is accepted in the `operator()`.
+    using option_value_type = std::any;
 
-    //!\brief Value cmp always passes validation because the operator never throws.
+    //!\brief Value cmp always passes validation for any type and never throws.
+    template <typename option_value_t>
     void operator()(option_value_t const & /*cmp*/) const noexcept
     {}
 

--- a/test/unit/format_parse_validators_test.cpp
+++ b/test/unit/format_parse_validators_test.cpp
@@ -51,11 +51,8 @@ TEST(validator_test, fullfill_concept)
 {
     EXPECT_FALSE(sharg::validator<int>);
 
-    EXPECT_TRUE(sharg::validator<sharg::detail::default_validator<int>>);
-    EXPECT_TRUE(sharg::validator<sharg::detail::default_validator<int> const>);
-    EXPECT_TRUE(sharg::validator<sharg::detail::default_validator<int> &>);
+    EXPECT_TRUE(sharg::validator<sharg::detail::default_validator>);
 
-    EXPECT_TRUE(sharg::validator<sharg::detail::default_validator<std::vector<int>>>);
     EXPECT_TRUE(sharg::validator<sharg::arithmetic_range_validator<int>>);
     EXPECT_TRUE(sharg::validator<sharg::value_list_validator<double>>);
     EXPECT_TRUE(sharg::validator<sharg::value_list_validator<std::string>>);


### PR DESCRIPTION
Part of https://github.com/seqan/sharg-parser/issues/76.

In order to create a config struct, the default validator type must be independent of the option value type. This is not necessary anyway.