### PR TITLE
[FIX] --version-check doesn't alter parser behaviour.

### DIFF
--- a/include/sharg/parser.hpp
+++ b/include/sharg/parser.hpp
@@ -715,12 +715,6 @@ private:
      */
     void init(int argc, char const * const * const argv)
     {
-        if (argc <= 1) // no arguments provided
-        {
-            format = detail::format_short_help{};
-            return;
-        }
-
         bool special_format_was_set{false};
 
         for (int i = 1, argv_len = argc; i < argv_len; ++i) // start at 1 to skip binary name
@@ -805,6 +799,14 @@ private:
             {
                 cmd_arguments.push_back(std::move(arg));
             }
+        }
+
+        // all special options have been identified, which might involve deleting them from argv (e.g. version-check)
+        // check if no actual options remain and then call the short help page.
+        if (argc <= 1) // no arguments provided
+        {
+            format = detail::format_short_help{};
+            return;
         }
 
         if (!special_format_was_set)

--- a/test/unit/detail/format_help_test.cpp
+++ b/test/unit/detail/format_help_test.cpp
@@ -88,7 +88,7 @@ TEST(help_page_printing, short_help)
     auto check_expected_short_help = [&](auto && argv)
     {
         int const argc = sizeof(argv) / sizeof(*argv);
-        sharg::parser parser{"empty_options", 1, argv};
+        sharg::parser parser{"empty_options", argc, argv};
         sharg::detail::test_accessor::set_terminal_width(parser, 80);
         parser.info.synopsis.push_back("./some_binary_name synopsis");
         int option_value{};


### PR DESCRIPTION
### Problem

`./my_app --version-check off`
has the same behavior as
`./my_app`
**IF** there is no required option.
If there is a required option, then an error is thrown: `required option -i is not set`

This PR fixes it. Now `./my_app --version-check off` and `./my_app` should always have the same behavior. The fix is a little indirect. The problem occurs because the `if (argc <= 1)` check that triggers the small-help-page for `./my_app` is before the `for` loop that will remove the `--version-check off` from the command line arguments of the parser. Checking it after the for loop ensures that the short-help-page is triggered regardless of the `version-check`.



