### PR TITLE
Doc/apistability

### DIFF
--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -20,7 +20,11 @@
 namespace sharg
 {
 
-//!\brief Indicates whether application allows automatic update notifications by the sharg::argument_parser.
+/*!\brief Indicates whether application allows automatic update notifications by the sharg::argument_parser.
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 enum class update_notifications
 {
     on, //!< Automatic update notifications should be enabled.
@@ -39,6 +43,9 @@ enum class update_notifications
  * point that can be easily extended.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
  */
 struct parser_meta_data // holds all meta information
 {

--- a/include/sharg/auxiliary.hpp
+++ b/include/sharg/auxiliary.hpp
@@ -20,7 +20,7 @@
 namespace sharg
 {
 
-/*!\brief Indicates whether application allows automatic update notifications by the sharg::argument_parser.
+/*!\brief Indicates whether application allows automatic update notifications by the sharg::parser.
  *
  * \details
  * \stableapi{Since version 1.0.}

--- a/include/sharg/concept.hpp
+++ b/include/sharg/concept.hpp
@@ -31,6 +31,9 @@ namespace sharg
  * ### Requirements
  *
  * `std::istream` must support the (un)formatted input function (`operator>>`) for an l-value of a given `value_type`.
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
  */
 // clang-format off
 template <typename value_type>
@@ -53,6 +56,8 @@ concept istreamable = requires (std::istream & is, value_type & val)
  *
  * `std::ostream` must support the (un)formatted output function (`operator<<`) for an l-value of a given `type` or
  * for an l-value of `type::reference`.
+ *
+ * \stableapi{Since version 1.0.}
  */
 // clang-format off
 template <typename type>
@@ -82,6 +87,8 @@ concept ostreamable = requires (std::ostream & os, type & val)
  * model sharg::named_enumeration<option_type>.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \stableapi{Since version 1.0.}
  */
 template <typename option_type>
 concept parsable =

--- a/include/sharg/config.hpp
+++ b/include/sharg/config.hpp
@@ -38,6 +38,8 @@ namespace sharg
  * | sharg::config::required             |           ✓          |      ✓      |             (✓)           |
  * | sharg::config::validator            |           ✓          |     (✓)     |              ✓            |
  *
+ * \details
+ * \stableapi{Since version 1.0.}
  */
 template <typename validator_t = detail::default_validator>
 struct config

--- a/include/sharg/enumeration_names.hpp
+++ b/include/sharg/enumeration_names.hpp
@@ -42,6 +42,9 @@ namespace sharg::custom
  * \ref tutorial_parser for an example of customising a type within your own namespace.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \experimentalapi{Experimental since version 1.0.}
  */
 template <typename t>
 struct parsing
@@ -204,6 +207,9 @@ namespace sharg
  *
  * This is a customisation point (see \ref about_customisation). To specify the behaviour for your type,
  * simply provide one of the two functions specified above.
+ *
+ * \details
+ * \experimentalapi{Experimental since version 1.0.}
  */
 // clang-format off
 template <typename option_type>
@@ -223,6 +229,9 @@ inline auto const enumeration_names = detail::adl_only::enumeration_names_cpo<op
  *   `std::unordered_map<std::string, option_type>`.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \experimentalapi{Experimental since version 1.0.}
  */
 // clang-format off
 template <typename option_type>
@@ -234,6 +243,10 @@ concept named_enumeration = requires
 } // namespace sharg
 
 //!\cond
+/*!\brief Overload of ostream operator<<
+ * \details
+ * \experimentalapi{Experimental since version 1.0.}
+ */
 template <typename option_type>
     requires sharg::named_enumeration<std::remove_cvref_t<option_type>>
 inline std::ostream & std::operator<<(std::ostream & s, option_type && op)

--- a/include/sharg/exceptions.hpp
+++ b/include/sharg/exceptions.hpp
@@ -35,103 +35,158 @@ namespace sharg
  * - Validation failed (as defined by the developer)
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
  */
 class parser_error : public std::runtime_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     parser_error(std::string const & s) : std::runtime_error(s)
     {}
 };
 
-//!\brief Parser exception thrown when encountering unknown option.
-//!\ingroup parser
-//!\remark For a complete overview, take a look at \ref parser
+/*!\brief Parser exception thrown when encountering unknown option.
+ * \ingroup parser
+ * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 class unknown_option : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     unknown_option(std::string const & s) : parser_error(s)
     {}
 };
 
-//!\brief Parser exception thrown when too many arguments are provided.
-//!\ingroup parser
-//!\remark For a complete overview, take a look at \ref parser
+/*!\brief Parser exception thrown when too many arguments are provided.
+ * \ingroup parser
+ * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 class too_many_arguments : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     too_many_arguments(std::string const & s) : parser_error(s)
     {}
 };
 
-//!\brief Parser exception thrown when too few arguments are provided.
-//!\ingroup parser
-//!\remark For a complete overview, take a look at \ref parser
+/*!\brief Parser exception thrown when too few arguments are provided.
+ * \ingroup parser
+ * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 class too_few_arguments : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     too_few_arguments(std::string const & s) : parser_error(s)
     {}
 };
 
-//!\brief Parser exception thrown when a required option is missing.
-//!\ingroup parser
-//!\remark For a complete overview, take a look at \ref parser
+/*!\brief Parser exception thrown when a required option is missing.
+ * \ingroup parser
+ * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 class required_option_missing : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     required_option_missing(std::string const & s) : parser_error(s)
     {}
 };
 
-//!\brief Parser exception thrown when a non-list option is declared multiple times.
-//!\ingroup parser
-//!\remark For a complete overview, take a look at \ref parser
+/*!\brief Parser exception thrown when a non-list option is declared multiple times.
+ * \ingroup parser
+ * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 class option_declared_multiple_times : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     option_declared_multiple_times(std::string const & s) : parser_error(s)
     {}
 };
 
-//!\brief Parser exception thrown when an incorrect argument is given as (positional) option value.
-//!\ingroup parser
-//!\remark For a complete overview, take a look at \ref parser
+/*!\brief Parser exception thrown when an incorrect argument is given as (positional) option value.
+ * \ingroup parser
+ * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 class user_input_error : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     user_input_error(std::string const & s) : parser_error(s)
     {}
 };
 
-//!\brief Parser exception thrown when an argument could not be casted to the according type.
-//!\ingroup parser
-//!\remark For a complete overview, take a look at \ref parser
+/*!\brief Parser exception thrown when an argument could not be casted to the according type.
+ * \ingroup parser
+ * \remark For a complete overview, take a look at \ref parser
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
+ */
 class validation_error : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     validation_error(std::string const & s) : parser_error(s)
     {}
@@ -147,12 +202,18 @@ public:
  * - Reuse of a short or long identifier (must be unique)
  * - Both identifiers must not be empty (one is ok)
  * - Flag default value must be false
+ *
+ * \details
+ * \stableapi{Since version 1.0.}
  */
 class design_error : public parser_error
 {
 public:
     /*!\brief The constructor.
      * \param[in] s The error message.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     design_error(std::string const & s) : parser_error(s)
     {}

--- a/include/sharg/parser.hpp
+++ b/include/sharg/parser.hpp
@@ -150,6 +150,7 @@ namespace sharg
  * Note that in case there is no `--version-check` option (display available options with `-h/--help)`,
  * then the developer already disabled the version check functionality.
  *
+ * \stableapi{Since version 1.0.}
  */
 class parser
 {
@@ -178,6 +179,9 @@ public:
      *
      * See the [parser tutorial](https://sharg.vercel.app/usr/html/tutorial_parser.html)
      * for more information about the version check functionality.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     parser(std::string const & app_name,
            int const argc,
@@ -237,6 +241,9 @@ public:
      * The `config.validator` must be applicable to the given output variable (\p value).
      *
      * \throws sharg::design_error
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     template <typename option_type, typename validator_type>
         requires (parsable<option_type> || parsable<std::ranges::range_value_t<option_type>>)
@@ -262,6 +269,8 @@ public:
      *
      * \throws sharg::design_error
      *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     template <typename validator_type>
         requires std::invocable<validator_type, bool>
@@ -301,6 +310,8 @@ public:
      * \details
      *
      * The `config.validator` must be applicable to the given output variable (\p value).
+     *
+     * \stableapi{Since version 1.0.}
      */
     template <typename option_type, typename validator_type>
         requires (parsable<option_type> || parsable<std::ranges::range_value_t<option_type>>)
@@ -387,6 +398,8 @@ public:
      * The Age App - [PARSER ERROR] Value cast failed for option -a: Argument abc
      *                              could not be casted to type (signed 32 bit integer).
      * ```
+     *
+     * \stableapi{Since version 1.0.}
      */
     void parse()
     {
@@ -427,8 +440,12 @@ public:
         parse_was_called = true;
     }
 
-    //!\brief Returns a reference to the sub-parser instance if
-    //!       \link subcommand_parse subcommand parsing \endlink was enabled.
+    /*!\brief Returns a reference to the sub-parser instance if
+     *       \link subcommand_parse subcommand parsing \endlink was enabled.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
+     */
     parser & get_sub_parser()
     {
         if (sub_parser == nullptr)
@@ -464,6 +481,9 @@ public:
      *   pass a short identifier, please pass it as a `char` not a `std::string`.
      * * the option identifier cannot be found in the list of valid option identifiers that were added to the parser
      *   via `sharg::parser::add_option()` calls beforehand.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     // clang-format off
     template <typename id_type>
@@ -503,7 +523,11 @@ public:
     /*!\brief Adds an help page section to the sharg::parser.
      * \param[in] title The title of the section.
      * \param[in] advanced_only If set to true, the section only shows when the user requested the advanced help page.
-     * \details This only affects the help page and other output formats.
+     * \details
+     *
+     * This only affects the help page and other output formats.
+     *
+     * \stableapi{Since version 1.0.}
      */
     void add_section(std::string const & title, bool const advanced_only = false)
     {
@@ -518,7 +542,11 @@ public:
     /*!\brief Adds an help page subsection to the sharg::parser.
      * \param[in] title The title of the subsection.
      * \param[in] advanced_only If set to true, the section only shows when the user requested the advanced help page.
-     * \details This only affects the help page and other output formats.
+     * \details
+     *
+     * This only affects the help page and other output formats.
+     *
+     * \stableapi{Since version 1.0.}
      */
     void add_subsection(std::string const & title, bool const advanced_only = false)
     {
@@ -537,6 +565,8 @@ public:
      * \details
      * If the line is not a paragraph (false), only one line break is appended, otherwise two line breaks are appended.
      * This only affects the help page and other output formats.
+     *
+     * \stableapi{Since version 1.0.}
      */
     void add_line(std::string const & text, bool is_paragraph = false, bool const advanced_only = false)
     {
@@ -564,6 +594,8 @@ public:
      *     -a, --age LONG
      *            Super important integer for age.
      *```
+     *
+     * \stableapi{Since version 1.0.}
      */
     void add_list_item(std::string const & key, std::string const & desc, bool const advanced_only = false)
     {
@@ -623,6 +655,8 @@ public:
      *     Penguin_Parade version: 2.0.0
      *     Sharg version: 0.1.0
      * ```
+     *
+     * \stableapi{Since version 1.0.}
      */
     parser_meta_data info;
 

--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -42,6 +42,8 @@ namespace sharg
  * You can learn more about Sharg validators in our tutorial \ref section_validation.
  *
  * To implement your own validator please refer to the detailed concept description below.
+ *
+ * \stableapi{Since version 1.0.}
  */
 // clang-format off
 template <typename validator_type>
@@ -69,6 +71,8 @@ concept validator = std::copyable<std::remove_cvref_t<validator_type>> &&
  * \include test/snippet/validators_1.cpp
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \stableapi{Since version 1.0.}
  */
 template <typename option_value_t>
     requires std::is_arithmetic_v<option_value_t>
@@ -81,6 +85,9 @@ public:
     /*!\brief The constructor.
      * \param[in] min_ Minimum set for the range to test.
      * \param[in] max_ Maximum set for the range to test.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     arithmetic_range_validator(option_value_type const min_, option_value_type const max_) :
         min{min_},
@@ -91,6 +98,9 @@ public:
     /*!\brief Tests whether cmp lies inside [`min`, `max`].
      * \param cmp The input value to check.
      * \throws sharg::validation_error
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     void operator()(option_value_type const & cmp) const
     {
@@ -103,6 +113,9 @@ public:
      *                    std::is_arithmetic_v.
      * \param  range      The input range to iterate over and check every element.
      * \throws sharg::validation_error
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     template <std::ranges::forward_range range_type>
         requires std::is_arithmetic_v<std::ranges::range_value_t<range_type>>
@@ -116,7 +129,11 @@ public:
                       });
     }
 
-    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    /*!\brief Returns a message that can be appended to the (positional) options help page info.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
+     */
     std::string get_help_page_message() const
     {
         return std::string{"Value must be in range "} + valid_range_str + ".";
@@ -151,6 +168,8 @@ private:
  * \include test/snippet/validators_2.cpp
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \stableapi{Since version 1.0.}
  */
 template <parsable option_value_t>
 class value_list_validator
@@ -173,6 +192,9 @@ public:
      * \tparam range_type The type of range; must model std::ranges::forward_range and value_list_validator::option_value_type
      *                    must be constructible from the rvalue reference type of the given range.
      * \param[in] rng The range of valid values to test.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     template <std::ranges::forward_range range_type>
         requires std::constructible_from<option_value_type, std::ranges::range_rvalue_reference_t<range_type>>
@@ -185,6 +207,9 @@ public:
      * \tparam option_types The type of option values in the parameter pack; The value_list_validator::option_value_type must
      *                      be constructible from each type in the parameter pack.
      * \param[in] opts The parameter pack values.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     template <typename... option_types>
         requires ((std::constructible_from<option_value_type, option_types> && ...))
@@ -197,6 +222,9 @@ public:
     /*!\brief Tests whether cmp lies inside values.
      * \param cmp The input value to check.
      * \throws sharg::validation_error
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     void operator()(option_value_type const & cmp) const
     {
@@ -208,6 +236,9 @@ public:
      * \tparam range_type The type of range to check; must model std::ranges::forward_range.
      * \param  range      The input range to iterate over and check every element.
      * \throws sharg::validation_error
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     template <std::ranges::forward_range range_type>
         requires std::convertible_to<std::ranges::range_value_t<range_type>, option_value_type>
@@ -221,7 +252,11 @@ public:
                       });
     }
 
-    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    /*!\brief Returns a message that can be appended to the (positional) options help page info.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
+     */
     std::string get_help_page_message() const
     {
         return detail::to_string("Value must be one of ", values, ".");
@@ -232,7 +267,7 @@ private:
     std::vector<option_value_type> values{};
 };
 
-/*!\brief Type deduction guides
+/*!\name Type deduction guides
  * \relates sharg::value_list_validator
  * \{
  */
@@ -270,6 +305,8 @@ value_list_validator(range_type && rng) -> value_list_validator<std::ranges::ran
  * using the template argument to determine the valid extensions from the given file type.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \experimentalapi{Experimental since version 1.0.}
  */
 class file_validator_base
 {
@@ -294,6 +331,8 @@ public:
      * \details
      *
      * This is a pure virtual function and must be overloaded by the derived class.
+     *
+     * \experimentalapi{Experimental since version 1.0.}
      */
     virtual void operator()(std::filesystem::path const & path) const = 0;
 
@@ -303,6 +342,9 @@ public:
      *                    be convertible to std::filesystem::path.
      * \param  v          The input range to iterate over and check every element.
      * \throws sharg::validation_error
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     template <std::ranges::forward_range range_type>
         requires (std::convertible_to<std::ranges::range_value_t<range_type>, std::filesystem::path const &>
@@ -464,6 +506,8 @@ protected:
  * \note The validator works on every type that can be implicitly converted to std::filesystem::path.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \experimentalapi{Experimental since version 1.0.}
  */
 class input_file_validator : public file_validator_base
 {
@@ -474,7 +518,6 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-
     input_file_validator() = default;                                         //!< Defaulted.
     input_file_validator(input_file_validator const &) = default;             //!< Defaulted.
     input_file_validator(input_file_validator &&) = default;                  //!< Defaulted.
@@ -484,6 +527,9 @@ public:
 
     /*!\brief Constructs from a given collection of valid extensions.
      * \param[in] extensions The valid extensions to validate for.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     explicit input_file_validator(std::vector<std::string> extensions) : file_validator_base{}
     {
@@ -502,6 +548,9 @@ public:
      * \param file The input value to check.
      * \throws sharg::validation_error if the validation process failed. Might be nested with
      *         std::filesystem::filesystem_error on unhandled OS API errors.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     virtual void operator()(std::filesystem::path const & file) const override
     {
@@ -528,7 +577,10 @@ public:
         }
     }
 
-    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    /*!\brief Returns a message that can be appended to the (positional) options help page info.
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
+     */
     std::string get_help_page_message() const
     {
         return "The input file must exist and read permissions must be granted."
@@ -537,7 +589,10 @@ public:
     }
 };
 
-//!\brief Mode of an output file: Determines whether an existing file can be (silently) overwritten.
+/*!\brief Mode of an output file: Determines whether an existing file can be (silently) overwritten.
+ * \details
+ * \experimentalapi{Experimental since version 1.0.}
+ */
 enum class output_file_open_options
 {
     //!\brief Allow to overwrite the output file
@@ -570,6 +625,8 @@ enum class output_file_open_options
  * \note The validator works on every type that can be implicitly converted to std::filesystem::path.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \experimentalapi{Experimental since version 1.0.}
  */
 class output_file_validator : public file_validator_base
 {
@@ -580,7 +637,6 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-
     output_file_validator() = default;                                          //!< Defaulted.
     output_file_validator(output_file_validator const &) = default;             //!< Defaulted.
     output_file_validator(output_file_validator &&) = default;                  //!< Defaulted.
@@ -592,6 +648,9 @@ public:
      * \param[in] mode A sharg::output_file_open_options indicating whether the validator throws if a file already
      *                 exists.
      * \param[in] extensions The valid extensions to validate for.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     explicit output_file_validator(output_file_open_options const mode, std::vector<std::string> const & extensions) :
         open_mode{mode}
@@ -605,6 +664,9 @@ public:
      *                 exists.
      * \param[in] extensions Parameter pack representing valid extensions. std::string must be constructible from each
      *                       argument. The pack may be empty ( → all extensions are valid).
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     explicit output_file_validator(output_file_open_options const mode, auto &&... extensions)
         requires ((std::constructible_from<std::string, decltype(extensions)> && ...))
@@ -613,6 +675,9 @@ public:
 
     /*!\brief Constructs from a list of valid extensions.
      * \param[in] extensions The valid extensions to validate for.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     explicit output_file_validator(std::vector<std::string> const & extensions) :
         output_file_validator{output_file_open_options::create_new, extensions}
@@ -621,6 +686,9 @@ public:
     /*!\brief Constructs from a parameter pack of valid extensions.
      * \param[in] extensions Parameter pack representing valid extensions. std::string must be constructible from each
      *                       argument. The pack may be empty ( → all extensions are valid).
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     explicit output_file_validator(auto &&... extensions)
         requires ((std::constructible_from<std::string, decltype(extensions)> && ...))
@@ -638,6 +706,9 @@ public:
      * \param file The input value to check.
      * \throws sharg::validation_error if the validation process failed. Might be nested with
      *         std::filesystem::filesystem_error on unhandled OS API errors.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     virtual void operator()(std::filesystem::path const & file) const override
     {
@@ -663,7 +734,11 @@ public:
         }
     }
 
-    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    /*!\brief Returns a message that can be appended to the (positional) options help page info.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
+     */
     std::string get_help_page_message() const
     {
         if (open_mode == output_file_open_options::open_or_create)
@@ -700,6 +775,8 @@ private:
  * \note The validator works on every type that can be implicitly converted to std::filesystem::path.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \experimentalapi{Experimental since version 1.0.}
  */
 class input_directory_validator : public file_validator_base
 {
@@ -728,6 +805,9 @@ public:
      * \param dir The input value to check.
      * \throws sharg::validation_error if the validation process failed. Might be nested with
      *         std::filesystem::filesystem_error on unhandled OS API errors.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     virtual void operator()(std::filesystem::path const & dir) const override
     {
@@ -754,7 +834,11 @@ public:
         }
     }
 
-    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    /*!\brief Returns a message that can be appended to the (positional) options help page info.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
+     */
     std::string get_help_page_message() const
     {
         return "An existing, readable path for the input directory.";
@@ -776,6 +860,8 @@ public:
  * \note The validator works on every type that can be implicitly converted to std::filesystem::path.
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \experimentalapi{Experimental since version 1.0.}
  */
 class output_directory_validator : public file_validator_base
 {
@@ -804,6 +890,9 @@ public:
      * \param dir The input value to check.
      * \throws sharg::validation_error if the validation process failed. Might be nested with
      *         std::filesystem::filesystem_error on unhandled OS API errors.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
      */
     virtual void operator()(std::filesystem::path const & dir) const override
     {
@@ -840,7 +929,11 @@ public:
         }
     }
 
-    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    /*!\brief Returns a message that can be appended to the (positional) options help page info.
+     *
+     * \details
+     * \experimentalapi{Experimental since version 1.0.}
+     */
     std::string get_help_page_message() const
     {
         return "A valid path for the output directory.";
@@ -865,6 +958,8 @@ public:
  * \include test/snippet/validators_4.cpp
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \stableapi{Since version 1.0.}
  */
 class regex_validator
 {
@@ -874,6 +969,9 @@ public:
 
     /*!\brief Constructing from a vector.
      * \param[in] pattern_ The pattern to match.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     regex_validator(std::string const & pattern_) : pattern{pattern_}
     {}
@@ -881,6 +979,9 @@ public:
     /*!\brief Tests whether cmp lies inside values.
      * \param[in] cmp The value to validate.
      * \throws sharg::validation_error
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     void operator()(option_value_type const & cmp) const
     {
@@ -894,6 +995,9 @@ public:
      *                    be convertible to std::string.
      * \param  v          The input range to iterate over and check every element.
      * \throws sharg::validation_error
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
      */
     template <std::ranges::forward_range range_type>
         requires std::convertible_to<std::ranges::range_reference_t<range_type>, std::string const &>
@@ -906,7 +1010,11 @@ public:
         }
     }
 
-    //!\brief Returns a message that can be appended to the (positional) options help page info.
+    /*!\brief Returns a message that can be appended to the (positional) options help page info.
+     *
+     * \details
+     * \stableapi{Since version 1.0.}
+     */
     std::string get_help_page_message() const
     {
         return "Value must match the pattern '" + pattern + "'.";
@@ -1051,6 +1159,8 @@ private:
  * the other from left to right (first to last).
  *
  * \remark For a complete overview, take a look at \ref parser
+ *
+ * \stableapi{Since version 1.0.}
  */
 template <validator validator1_type, validator validator2_type>
     requires std::common_with<typename std::remove_reference_t<validator1_type>::option_value_type,


### PR DESCRIPTION
Add stableapi and experimentalapi to most function.

Two concepts are missing a stableapi mark:
 - ostreamable (there is going to be a slight change of concept)
 - parser_compatible_option (this is going to be renamed)

Also, `inline std::ostream & std::operator<<(std::ostream & s, option_type && op)` is excluded from documentation, because it otherwise throws a doxygen warning:

```
sharg-parser/include/sharg/enumeration_names.hpp:251: warning: documented symbol 'std::ostream & std::operator<<' was not declared or defined.
```

