### PR TITLE
[INFRA] Bump CMake

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CMAKE_VERSION: 3.10.3
+  CMAKE_VERSION: 3.15.7
   SHARG_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CMAKE_VERSION: 3.10.3
+  CMAKE_VERSION: 3.15.7
   SHARG_NO_VERSION_CHECK: 1
   TZ: Europe/Berlin
 

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -44,7 +44,7 @@ jobs:
             build_threads: 2
             test_threads: 1 # snippets create and delete files and some separate tests create/delete the same files
             cxx_flags: "-std=c++20"
-            cmake: 3.10.3
+            cmake: 3.15.7
             requires_toolchain: true
             requires_ccache: true
             skip_build_tests: false
@@ -57,7 +57,7 @@ jobs:
             build_type: Debug
             build_threads: 2
             test_threads: 2
-            cmake: 3.10.3
+            cmake: 3.15.7
             requires_toolchain: true
             requires_ccache: true
             skip_build_tests: false
@@ -70,7 +70,7 @@ jobs:
             build_type: Debug
             build_threads: 2
             test_threads: 2
-            cmake: 3.10.3
+            cmake: 3.15.7
             requires_toolchain: true
             requires_ccache: true
             skip_build_tests: false
@@ -80,7 +80,7 @@ jobs:
             build: documentation
             build_threads: 2
             test_threads: 2
-            cmake: 3.10.3
+            cmake: 3.15.7
             doxygen: 1.9.4
             requires_toolchain: false
             requires_ccache: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,28 +6,22 @@
 # --------------------------------------------------------------------------------------------------------
 
 # This file provides functionality common to the different test modules used by
-# SeqAn3. To build tests, run cmake on one of the sub-folders in this directory
+# Sharg. To build tests, run cmake on one of the sub-folders in this directory
 # which contain a CMakeLists.txt.
 
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.12)
 
 find_path (SHARG_MODULE_PATH "sharg-config.cmake" HINTS "${CMAKE_CURRENT_LIST_DIR}/build_system/")
 list (APPEND CMAKE_MODULE_PATH "${SHARG_MODULE_PATH}")
 
 include (sharg-config-version)
 
-if (CMAKE_VERSION VERSION_LESS 3.12)
-    project (sharg
-             LANGUAGES CXX
-             VERSION "${SHARG_PROJECT_VERSION}")
-else ()
-    project (sharg
-             LANGUAGES CXX
-             VERSION "${SHARG_PROJECT_VERSION}"
-             DESCRIPTION "Sharg -- hungrily eating away your arguments" # since cmake 3.9
-             HOMEPAGE_URL "https://github.com/seqan/sharg-parser" # since cmake 3.12
-    )
-endif ()
+project (sharg
+            LANGUAGES CXX
+            VERSION "${SHARG_PROJECT_VERSION}"
+            DESCRIPTION "Sharg -- hungrily eating away your arguments"
+            HOMEPAGE_URL "https://github.com/seqan/sharg-parser"
+)
 
 find_package (Sharg 1.0 REQUIRED HINTS ${SHARG_MODULE_PATH})
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ VERSION
 |                   | requirement                                          | version  | comment                                     |
 |-------------------|------------------------------------------------------|----------|---------------------------------------------|
 |**compiler**       | [GCC](https://gcc.gnu.org)                           | ≥ 10     | no other compiler is currently supported!   |
-|**build system**   | [CMake](https://cmake.org)                           | ≥ 3.4    | optional, but recommended                   |
+|**build system**   | [CMake](https://cmake.org)                           | ≥ 3.15   | optional, but recommended                   |
 
 
 ## Sponsorships

--- a/test/cmake/include_dependencies/generate_include_dependencies.cmake
+++ b/test/cmake/include_dependencies/generate_include_dependencies.cmake
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
 # --------------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.12)
 
 function (generate_include_dependencies_impl)
     cmake_parse_arguments (
@@ -47,17 +47,7 @@ function (generate_include_dependencies_impl)
 
     # filter out object files, e.g., discard "utility/views/CMakeFiles/zip_test.dir/zip_test.cpp.o: " in the line
     # `utility/views/CMakeFiles/zip_test.dir/zip_test.cpp.o: /seqan3/include/seqan3/core/platform.hpp`
-    if (CMAKE_VERSION VERSION_LESS 3.12)
-        set (_header_files "${header_files}")
-        set (header_files "")
-        foreach (header_file ${_header_files})
-            string (REGEX REPLACE "^.+: " "" header_file "${header_file}")
-            list (APPEND header_files "${header_file}")
-        endforeach ()
-    else () # ^^^ workaround / no workaround vvv
-        # list (TRANSFORM) needs cmake >= 3.12
-        list (TRANSFORM header_files REPLACE "^.+: " "")
-    endif ()
+    list (TRANSFORM header_files REPLACE "^.+: " "")
 
     if (NOT header_files)
         # The pre-processing step that generates the dependency file did not produce it.

--- a/test/cmake/sharg_require_benchmark.cmake
+++ b/test/cmake/sharg_require_benchmark.cmake
@@ -5,92 +5,31 @@
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
 # --------------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.10)
+# 3.14 is enough for the FetchContent feature, but it has a bug that prevents it from working.
+cmake_minimum_required (VERSION 3.15)
 
 # Exposes the google-benchmark target `gbenchmark`.
-macro (sharg_require_benchmark_old gbenchmark_git_tag)
-    set (SHARG_BENCHMARK_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/benchmark")
-
-    # needed for add_library (seqan3::test::* INTERFACE IMPORTED)
-    # see cmake bug https://gitlab.kitware.com/cmake/cmake/issues/15052
-    file (MAKE_DIRECTORY ${SHARG_BENCHMARK_CLONE_DIR}/include/)
-
-    set (gbenchmark_project_args ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS})
-    list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_TESTING=false")
-    list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_WERROR=false") # Does not apply to Debug builds.
-    # google-benchmarks suggest to use LTO (link-time optimisation), but we don't really need that because we are a
-    # header only library. This option might be still interesting for external libraries benchmarks.
-    # see https://github.com/google/benchmark#debug-vs-release
-    # list (APPEND gbenchmark_project_args "-DBENCHMARK_ENABLE_LTO=true")
-
-    # force that libraries are installed to `lib/`, because GNUInstallDirs might install it into `lib64/`
-    list (APPEND gbenchmark_project_args "-DCMAKE_INSTALL_LIBDIR=${PROJECT_BINARY_DIR}/lib/")
-
-    include (ExternalProject)
-    ExternalProject_Add (
-        gbenchmark_project
-        PREFIX gbenchmark_project
-        GIT_REPOSITORY "https://github.com/google/benchmark.git"
-        GIT_TAG "${gbenchmark_git_tag}"
-        SOURCE_DIR "${SHARG_BENCHMARK_CLONE_DIR}"
-        CMAKE_ARGS "${gbenchmark_project_args}"
-        BUILD_BYPRODUCTS "${gbenchmark_path}"
-        UPDATE_DISCONNECTED ${SHARG_TEST_BUILD_OFFLINE})
-    unset (gbenchmark_project_args)
-
-    foreach (lname "benchmark" "benchmark_main")
-        add_library (lib${lname} STATIC IMPORTED)
-        set_target_properties (
-            lib${lname}
-            PROPERTIES IMPORTED_LOCATION
-                       "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${lname}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    endforeach ()
-
-    add_library (gbenchmark INTERFACE)
-    add_dependencies (gbenchmark gbenchmark_project)
-    target_link_libraries (gbenchmark INTERFACE "libbenchmark" "libbenchmark_main" "pthread")
-    include_directories (gbenchmark INTERFACE "${PROJECT_BINARY_DIR}/include/")
-
-    # NOTE: google benchmarks needs Shlwapi (Shell Lightweight Utility Functions) on windows
-    # see https://msdn.microsoft.com/en-us/library/windows/desktop/bb759844(v=vs.85).aspx
-    # see https://github.com/google/benchmark/blob/c614dfc0d4eadcd19b188ff9c7e226c138f894a1/README.md#platform-specific-libraries
-    if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-        target_link_libraries (gbenchmark INTERFACE "Shlwapi")
-    endif ()
-
-endmacro ()
-
 macro (sharg_require_benchmark)
     enable_testing ()
 
     set (gbenchmark_git_tag "v1.6.1")
 
-    if (NOT CMAKE_VERSION VERSION_LESS 3.14)
-        message (STATUS "Fetch Google Benchmark:")
+    message (STATUS "Fetch Google Benchmark:")
 
-        include (FetchContent)
-        FetchContent_Declare (
-            gbenchmark_fetch_content
-            GIT_REPOSITORY "https://github.com/google/benchmark.git"
-            GIT_TAG "${gbenchmark_git_tag}")
-        option (BENCHMARK_ENABLE_TESTING "" OFF)
-        option (BENCHMARK_ENABLE_WERROR "" OFF) # Does not apply to Debug builds.
-        FetchContent_MakeAvailable (gbenchmark_fetch_content)
+    include (FetchContent)
+    FetchContent_Declare (
+        gbenchmark_fetch_content
+        GIT_REPOSITORY "https://github.com/google/benchmark.git"
+        GIT_TAG "${gbenchmark_git_tag}")
+    option (BENCHMARK_ENABLE_TESTING "" OFF)
+    option (BENCHMARK_ENABLE_WERROR "" OFF) # Does not apply to Debug builds.
+    FetchContent_MakeAvailable (gbenchmark_fetch_content)
 
-        # NOTE: google benchmark's CMakeLists.txt already defines Shlwapi
-        add_library (gbenchmark ALIAS benchmark_main)
+    # NOTE: google benchmark's CMakeLists.txt already defines Shlwapi
+    add_library (gbenchmark ALIAS benchmark_main)
 
-        if (NOT TARGET gbenchmark_build)
-            add_custom_target (gbenchmark_build DEPENDS gbenchmark)
-            target_compile_options ("benchmark_main" PUBLIC "-w")
-        endif ()
-    else ()
-        message (STATUS "Use Google Benchmark as external project:")
-
-        sharg_require_benchmark_old ("${gbenchmark_git_tag}")
-
-        if (NOT TARGET gbenchmark_build)
-            add_custom_target (gbenchmark_build DEPENDS gbenchmark)
-        endif ()
+    if (NOT TARGET gbenchmark_build)
+        add_custom_target (gbenchmark_build DEPENDS gbenchmark)
+        target_compile_options ("benchmark_main" PUBLIC "-w")
     endif ()
 endmacro ()

--- a/test/cmake/sharg_require_ccache.cmake
+++ b/test/cmake/sharg_require_ccache.cmake
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
 # --------------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.15)
 
 # Uses `ccache` to cache build results.
 #
@@ -20,15 +20,7 @@ macro (sharg_require_ccache)
         find_package_message (CCACHE_PROGRAM "Finding program ccache - Failed" "[${CCACHE_PROGRAM}]")
     else ()
         find_package_message (CCACHE_PROGRAM "Finding program ccache - Success" "[${CCACHE_PROGRAM}]")
-        # New option since cmake >= 3.4:
-        # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_LAUNCHER.html
-        if (NOT CMAKE_VERSION VERSION_LESS 3.15) # cmake >= 3.15
-            list (PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
-        else ()
-            # prepend ccache to CMAKE_CXX_COMPILER_LAUNCHER
-            list (INSERT CMAKE_CXX_COMPILER_LAUNCHER 0 "${CCACHE_PROGRAM}")
-        endif ()
-
+        list (PREPEND CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
         # use ccache in external cmake projects
         list (APPEND SHARG_EXTERNAL_PROJECT_CMAKE_ARGS "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
     endif ()

--- a/test/cmake/sharg_require_test.cmake
+++ b/test/cmake/sharg_require_test.cmake
@@ -5,93 +5,28 @@
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
 # --------------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.10)
+# 3.14 is enough for the FetchContent feature, but it has a bug that prevents it from working.
+cmake_minimum_required (VERSION 3.15)
 
 # Exposes the google-test targets `gtest` and `gtest_main`.
-macro (sharg_require_test_old gtest_git_tag)
-    set (SHARG_TEST_CLONE_DIR "${PROJECT_BINARY_DIR}/vendor/googletest")
-
-    # needed for add_library (seqan3::test::* INTERFACE IMPORTED)
-    # see cmake bug https://gitlab.kitware.com/cmake/cmake/issues/15052
-    file (MAKE_DIRECTORY ${SHARG_TEST_CLONE_DIR}/googletest/include/)
-
-    set (gtest_project_args ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS})
-    list (APPEND gtest_project_args "-DBUILD_GMOCK=0")
-
-    # force that libraries are installed to `lib/`, because GNUInstallDirs might install it into `lib64/`
-    list (APPEND gtest_project_args "-DCMAKE_INSTALL_LIBDIR=${PROJECT_BINARY_DIR}/lib/")
-
-    # google sets CMAKE_DEBUG_POSTFIX = "d"
-    set (gtest_main_path
-         "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set (gtest_main_path
-             "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_maind${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    endif ()
-
-    set (gtest_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set (gtest_path "${PROJECT_BINARY_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gtestd${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    endif ()
-
-    include (ExternalProject)
-    ExternalProject_Add (
-        gtest_project
-        PREFIX gtest_project
-        GIT_REPOSITORY "https://github.com/google/googletest.git"
-        GIT_TAG "${gtest_git_tag}"
-        SOURCE_DIR "${SHARG_TEST_CLONE_DIR}"
-        CMAKE_ARGS "${gtest_project_args}"
-        BUILD_BYPRODUCTS "${gtest_main_path}" "${gtest_path}"
-        UPDATE_DISCONNECTED ${SHARG_TEST_BUILD_OFFLINE})
-    unset (gtest_project_args)
-
-    add_library (gtest_main STATIC IMPORTED)
-    add_dependencies (gtest_main gtest_project)
-    set_target_properties (gtest_main PROPERTIES IMPORTED_LOCATION "${gtest_main_path}")
-
-    add_library (gtest STATIC IMPORTED)
-    add_dependencies (gtest gtest_project)
-    set_target_properties (gtest PROPERTIES IMPORTED_LOCATION "${gtest_path}")
-    set_property (TARGET gtest
-                  APPEND
-                  PROPERTY INTERFACE_LINK_LIBRARIES "pthread")
-    set_property (TARGET gtest
-                  APPEND
-                  PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SHARG_TEST_CLONE_DIR}/googletest/include/")
-
-    unset (gtest_main_path)
-    unset (gtest_path)
-endmacro ()
-
 macro (sharg_require_test)
     enable_testing ()
 
     set (gtest_git_tag "release-1.11.0")
 
-    if (NOT CMAKE_VERSION VERSION_LESS 3.14)
-        message (STATUS "Fetch Google Test:")
+    message (STATUS "Fetch Google Test:")
 
-        include (FetchContent)
-        FetchContent_Declare (
-            gtest_fetch_content
-            GIT_REPOSITORY "https://github.com/google/googletest.git"
-            GIT_TAG "${gtest_git_tag}")
-        option (BUILD_GMOCK "" OFF)
-        FetchContent_MakeAvailable (gtest_fetch_content)
+    include (FetchContent)
+    FetchContent_Declare (
+        gtest_fetch_content
+        GIT_REPOSITORY "https://github.com/google/googletest.git"
+        GIT_TAG "${gtest_git_tag}")
+    option (BUILD_GMOCK "" OFF)
+    FetchContent_MakeAvailable (gtest_fetch_content)
 
-        if (NOT TARGET gtest_build)
-            add_custom_target (gtest_build DEPENDS gtest_main gtest)
-            target_compile_options ("gtest_main" PUBLIC "-w")
-            target_compile_options ("gtest" PUBLIC "-w")
-        endif ()
-    else ()
-        message (STATUS "Use Google Test as external project:")
-
-        sharg_require_test_old ("${gtest_git_tag}")
-
-        if (NOT TARGET gtest_build)
-            add_custom_target (gtest_build DEPENDS gtest_main gtest)
-        endif ()
+    if (NOT TARGET gtest_build)
+        add_custom_target (gtest_build DEPENDS gtest_main gtest)
+        target_compile_options ("gtest_main" PUBLIC "-w")
+        target_compile_options ("gtest" PUBLIC "-w")
     endif ()
 endmacro ()

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -5,7 +5,7 @@
 # shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
 # --------------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.12)
 project (sharg_header_test CXX)
 
 include (../sharg-test.cmake)
@@ -48,15 +48,7 @@ macro (sharg_header_test component header_base_path exclude_regex)
                                         "${CMAKE_CURRENT_SOURCE_DIR}/generate_header_source.cmake")
             add_library (${header_target} OBJECT "${header_target_source}")
 
-            if (CMAKE_VERSION VERSION_LESS 3.12)
-                target_compile_options (${header_target} PRIVATE $<TARGET_PROPERTY:sharg::test::header,INTERFACE_COMPILE_OPTIONS>)
-                target_compile_definitions (${header_target} PRIVATE $<TARGET_PROPERTY:sharg::test::header,INTERFACE_COMPILE_DEFINITIONS>)
-                target_include_directories (${header_target} PRIVATE $<TARGET_PROPERTY:sharg::test::header,INTERFACE_INCLUDE_DIRECTORIES>)
-                target_include_directories (${header_target} SYSTEM PRIVATE $<TARGET_PROPERTY:sharg::test::header,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
-                add_dependencies (${header_target} gtest gbenchmark)
-            else ()
-                target_link_libraries (${header_target} sharg::test::header)
-            endif ()
+            target_link_libraries (${header_target} sharg::test::header)
 
             target_sources (${target} PRIVATE $<TARGET_OBJECTS:${header_target}>)
         endforeach ()


### PR DESCRIPTION
Since CMake 3.15.7 was released over 2.5 years ago, I think it's OK to require at least 3.15.7. This simplifies some CMake.

I'll check if we can get rid of more, but these are the low-hanging fruits.