### PR TITLE
[DOC] Remove API badge from groupheader

### DIFF
--- a/test/documentation/api-stability.js
+++ b/test/documentation/api-stability.js
@@ -56,7 +56,4 @@ $(document).ready(function()
         select_and_add_label.call(this, this, "member");
     });
 
-    // Badge for "Detailed Description"
-    select_and_add_label($('div.textblock'), "header");
-
 });


### PR DESCRIPTION
This usually puts a API badge next to `Detailed Description`.
However,
* for actual doxygen groups, this is `no-api` if not documented
* We don't really want this for doxygen groups