### PR TITLE
[FIX] Raise an error if subcommand is misspelled and ignore trailing -h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 
 ## API changes
 
+## Bug fixes
+
+* When using subcommand parsers, e.g. `git push`, typing `git puhs -h` will raise an exception that the user misspelled
+  the subcommand instead of printing the help page of `git` ([\#172](https://github.com/seqan/sharg-parser/pull/172)).
+
 #### Dependencies
   * We now use Doxygen version 1.9.5 to build our documentation ([\#145](https://github.com/seqan/sharg-parser/pull/145)).
   * We require at least CMake 3.16 for our test suite. Note that the minimum requirement for using Sharg is unchanged

--- a/test/unit/parser/format_parse_test.cpp
+++ b/test/unit/parser/format_parse_test.cpp
@@ -892,10 +892,26 @@ TEST(parse_test, subcommand_parser_success)
 
 TEST(parse_test, subcommand_parser_error)
 {
-    // incorrect sub command
-    char const * argv[]{"./top_level", "subiddysub", "-f"};
+    // incorrect sub command regardless of following arguments
     { // see issue https://github.com/seqan/seqan3/issues/2172
-        sharg::parser top_level_parser{"top_level", 3, argv, sharg::update_notifications::off, {"sub1", "sub2"}};
+        std::array argv{"./top_level", "subiddysub", "-f"};
+        sharg::parser top_level_parser{"top", argv.size(), argv.data(), sharg::update_notifications::off, {"sub1"}};
+
+        EXPECT_THROW(top_level_parser.parse(), sharg::parser_error);
+    }
+
+    // incorrect sub command with no other arguments
+    {
+        std::array argv{"./top_level", "subiddysub"};
+        sharg::parser top_level_parser{"top", argv.size(), argv.data(), sharg::update_notifications::off, {"sub1"}};
+
+        EXPECT_THROW(top_level_parser.parse(), sharg::parser_error);
+    }
+
+    // incorrect sub command with trailing special option
+    { // see issue https://github.com/seqan/sharg-parser/issues/171
+        std::array argv{"./top_level", "subiddysub", "-h"};
+        sharg::parser top_level_parser{"top", argv.size(), argv.data(), sharg::update_notifications::off, {"sub1"}};
 
         EXPECT_THROW(top_level_parser.parse(), sharg::parser_error);
     }

--- a/test/unit/parser/format_parse_test.cpp
+++ b/test/unit/parser/format_parse_test.cpp
@@ -883,17 +883,21 @@ TEST(parse_test, subcommand_parser_success)
         EXPECT_FALSE(std::string{testing::internal::GetCapturedStdout()}.empty());
     }
 
+    // sub command may contain dash, see https://github.com/seqan/product_backlog/issues/234
+    {
+        char const * argv[]{"./top_level", "-dash"};
+        EXPECT_NO_THROW((sharg::parser{"top_level", 2, argv, sharg::update_notifications::off, {"-dash"}}));
+    }
+}
+
+TEST(parse_test, subcommand_parser_error)
+{
     // incorrect sub command
     char const * argv[]{"./top_level", "subiddysub", "-f"};
     { // see issue https://github.com/seqan/seqan3/issues/2172
         sharg::parser top_level_parser{"top_level", 3, argv, sharg::update_notifications::off, {"sub1", "sub2"}};
 
         EXPECT_THROW(top_level_parser.parse(), sharg::parser_error);
-    }
-
-    // sub command can contain dash, see https://github.com/seqan/product_backlog/issues/234
-    {
-        EXPECT_NO_THROW((sharg::parser{"top_level", 2, argv, sharg::update_notifications::off, {"-dash"}}));
     }
 }
 


### PR DESCRIPTION
Fixes #171 

### This fixes the following:

Given a parser `foo` with subcommands `bar1` and `bar2`.

```
./foo barX -h
```

will now raise an error that the subcommand was misspelled instead of printing the help page for `foo`.
