### PR TITLE
[FIX] output_file_validator deletes directories

### DIFF
--- a/include/sharg/validators.hpp
+++ b/include/sharg/validators.hpp
@@ -437,6 +437,9 @@ protected:
      */
     void validate_writeability(std::filesystem::path const & path) const
     {
+        if (std::filesystem::is_directory(path))
+            throw validation_error{"\"" + path.string() + "\" is a directory. Cannot validate writeability."};
+
         std::ofstream file{path};
         sharg::detail::safe_filesystem_entry file_guard{path};
 
@@ -712,6 +715,9 @@ public:
      */
     virtual void operator()(std::filesystem::path const & file) const override
     {
+        if (std::filesystem::is_directory(file))
+            throw validation_error{"\"" + file.string() + "\" is a directory. Expected a file."};
+
         try
         {
             if ((open_mode == output_file_open_options::create_new) && std::filesystem::exists(file))


### PR DESCRIPTION
For example, `--output .` will delete the current directory when using `output_file_validator`.
`validate_writeability` is called with `.` and then tries to open `.`.

As this is a rather serious bug, I'll do Changelog/tests/reviews after merging.

Thanks to @pirovc for sacrificing his directory (which luckily contained nothing irreplaceable).