### PR TITLE
nothing here

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -131,4 +131,4 @@ jobs:
       - name: Run tests
         run: |
           cd sharg-build
-          ctest . -j2 --output-on-failure
+          script --return quiet -c "ctest . -j2 --output-on-failure"


### PR DESCRIPTION
sharg-parser is failing on my machine, and it is what I would expect...
So why isn't it failing on the ci?


So running `./detail/format_help_test` fails, because it print additional formatting (bold) terminal tags. This can be avoided by running `true | ./detail/format_help_test`

We could also handle this the otherway around, and force the unittests to use a terminal.
We could archive this by running ` script --return --quiet -c "ctest ."` instead of ctest directly.