### PR TITLE
[FIX] Handling of is_terminal

### DIFF
--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -241,17 +241,17 @@ protected:
                     assert(it != str.end());
                     if (*it == 'I')
                     {
-                        if (is_terminal())
+                        if (stdout_is_terminal())
                             result.append("\033[4m");
                     }
                     else if (*it == 'B')
                     {
-                        if (is_terminal())
+                        if (stdout_is_terminal())
                             result.append("\033[1m");
                     }
                     else if (*it == 'P')
                     {
-                        if (is_terminal())
+                        if (stdout_is_terminal())
                             result.append("\033[0m");
                     }
                     else

--- a/include/sharg/detail/terminal.hpp
+++ b/include/sharg/detail/terminal.hpp
@@ -14,33 +14,61 @@
 #pragma once
 
 #ifndef _WIN32
+#    include <unistd.h>
+
 #    include <sys/ioctl.h>
 #else
-#    include <windows.h>
+#    include <io.h>
+#    include <stdio.h>
 #endif
-
-#include <cstdio>
-#include <unistd.h>
 
 #include <sharg/platform.hpp>
 
 namespace sharg::detail
 {
 
-// ----------------------------------------------------------------------------
-// Function is_terminal()
-// ----------------------------------------------------------------------------
-
-/*!\brief Check whether we are printing to a terminal.
+/*!\brief Check whether the standard input is interactive.
  * \ingroup parser
- * \return True if code is run in a terminal, false otherwise.
+ * \return True if standard input is a terminal, false otherwise.
+ * \details
+ * For example "./some_binary --help | less" will return false. "./some_binary --help" will return true.
  */
-inline bool is_terminal()
+inline bool stdin_is_terminal()
 {
 #ifndef _WIN32
     return isatty(STDIN_FILENO);
 #else
-    return false;
+    return _isatty(_fileno(stdin));
+#endif
+}
+
+/*!\brief Check whether the standard output is interactive.
+ * \ingroup parser
+ * \return True if standard output is a terminal, false otherwise.
+ * \details
+ * For example "./some_binary --help | less" will return false. "./some_binary --help" will return true.
+ */
+inline bool stdout_is_terminal()
+{
+#ifndef _WIN32
+    return isatty(STDOUT_FILENO);
+#else
+    return _isatty(_fileno(stdout));
+#endif
+}
+
+/*!\brief Check whether the standard error output is interactive.
+ * \ingroup parser
+ * \return True if standard error output is a terminal, false otherwise.
+ * \details
+ * For example "./some_binary --help 2> cerr.out" will return false. "./some_binary --help" will return true.
+ */
+inline bool stderr_is_terminal()
+{
+#ifndef _WIN32
+    return isatty(STDERR_FILENO);
+#else
+    return _isatty(_fileno(stderr));
 #endif
 }
 
@@ -70,7 +98,7 @@ inline unsigned get_terminal_width()
 
     return w.ws_col;
 #else
-    return 80; // not implemented in windows
+    return 80; // Not implemented for Windows yet. For inspiration, see https://stackoverflow.com/a/12642749.
 #endif
 }
 

--- a/include/sharg/detail/version_check.hpp
+++ b/include/sharg/detail/version_check.hpp
@@ -287,7 +287,7 @@ public:
      * * ASK: Ask the user or default the decision once a day.
      *
      * If the cookie content is "ASK" and the timestamp is older than a day we ask the user,
-     * if possible (sharg::detail::is_terminal()), what he wants to do, set the according cookie for the next time
+     * if possible, what he wants to do, set the according cookie for the next time
      * and continue. If we cannot ask the user, the default kicks in (do the check).
      */
     bool decide_if_check_is_performed(update_notifications developer_approval, std::optional<bool> user_approval)
@@ -336,7 +336,7 @@ public:
         // nor did the the cookie tell us what to do. We will now ask the user if possible or do the check by default.
         write_cookie("ASK"); // Ask again next time when we read the cookie, if this is not overwritten.
 
-        if (detail::is_terminal()) // LCOV_EXCL_START
+        if (detail::stdin_is_terminal() && detail::stderr_is_terminal()) // LCOV_EXCL_START
         {
             std::cerr << R"(
 #######################################################################
@@ -385,7 +385,7 @@ public:
             }
             }
         }
-        else // if !detail::is_terminal()
+        else // of: if (detail::stdin_is_terminal() && detail::stderr_is_terminal())
         {
             return false; // default: do not check version today, if you cannot ask the user
         }

--- a/test/unit/detail/version_check_test.hpp
+++ b/test/unit/detail/version_check_test.hpp
@@ -250,7 +250,7 @@ TEST_F(version_check, option_on)
 }
 
 // Note that we cannot test interactiveness because google test captures std::cin and thus
-// sharg::detail::is_terminal() is always false
+// sharg::detail::input_is_terminal() is always false
 TEST_F(version_check, option_implicitely_on)
 {
     char const * argv[2] = {app_name.c_str(), "-f"};


### PR DESCRIPTION
Should actually fix https://github.com/seqan/sharg-parser/pull/184, because we now only format the output, if the standard output is a terminal. Before, we checked for standard input.