### PR TITLE
[MISC] Move std::exit for special formats to parser

### DIFF
--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -357,8 +357,6 @@ public:
         print_legal();
 
         derived_t().print_footer();
-
-        std::exit(EXIT_SUCCESS); // program should not continue from here
     }
 
     /*!\brief Adds a print_section call to parser_set_up_calls.

--- a/include/sharg/detail/format_help.hpp
+++ b/include/sharg/detail/format_help.hpp
@@ -422,8 +422,6 @@ public:
             print_synopsis();
 
         print_line("Try -h or --help for more information.\n", true);
-
-        std::exit(EXIT_SUCCESS);
     }
 };
 
@@ -450,8 +448,6 @@ public:
 
         print_header();
         print_version();
-
-        std::exit(EXIT_SUCCESS); // program should not continue from here
     }
 };
 
@@ -526,8 +522,6 @@ DAMAGE.)"};
                   << in_bold("This program contains SeqAn code licensed under the following terms:\n")
                   << std::string(80, '-') << '\n'
                   << seqan_license << '\n';
-
-        std::exit(EXIT_SUCCESS);
     }
 };
 

--- a/include/sharg/parser.hpp
+++ b/include/sharg/parser.hpp
@@ -440,6 +440,10 @@ public:
             },
             format);
         parse_was_called = true;
+
+        // Exit after parsing any special format.
+        if (!std::holds_alternative<detail::format_parse>(format))
+            std::exit(EXIT_SUCCESS);
     }
 
     /*!\brief Returns a reference to the sub-parser instance if


### PR DESCRIPTION
Exit in the `parse()` function instead of in the format itself. Arguably a better design. May also be needed for https://github.com/seqan/sharg-parser/pull/173