### PR TITLE
[MISC] clang preparation

### DIFF
--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -222,8 +222,8 @@ public:
     /*!\brief Adds a sharg::print_list_item call to be evaluated later on.
      * \copydetails sharg::parser::add_option
      */
-    template <typename option_type, typename config_type>
-    void add_option(option_type & value, config_type const & config)
+    template <typename option_type, typename validator_t>
+    void add_option(option_type & value, config<validator_t> const & config)
     {
         std::string id = prep_id_for_help(config.short_id, config.long_id) + " " + option_type_and_list_info(value);
         std::string info{config.description};
@@ -245,8 +245,8 @@ public:
     /*!\brief Adds a sharg::print_list_item call to be evaluated later on.
      * \copydetails sharg::parser::add_flag
      */
-    template <typename config_type>
-    void add_flag(bool & SHARG_DOXYGEN_ONLY(value), config_type const & config)
+    template <typename validator_t>
+    void add_flag(bool & SHARG_DOXYGEN_ONLY(value), config<validator_t> const & config)
     {
         store_help_page_element(
             [this, id = prep_id_for_help(config.short_id, config.long_id), description = config.description]()
@@ -259,8 +259,8 @@ public:
     /*!\brief Adds a sharg::print_list_item call to be evaluated later on.
      * \copydetails sharg::parser::add_positional_option
      */
-    template <typename option_type, typename config_type>
-    void add_positional_option(option_type & value, config_type const & config)
+    template <typename option_type, typename validator_t>
+    void add_positional_option(option_type & value, config<validator_t> const & config)
     {
         positional_option_calls.push_back(
             [this, &value, description = config.description, validator = config.validator]()
@@ -571,7 +571,8 @@ private:
      * If `config.advanced = true`, the information is only added to the help page if
      * the advanced help page has been queried on the command line (`show_advanced_options == true`).
      */
-    void store_help_page_element(std::function<void()> printer, config<auto> const & config)
+    template <typename validator_t>
+    void store_help_page_element(std::function<void()> printer, config<validator_t> const & config)
     {
         if (!(config.hidden) && (!(config.advanced) || show_advanced_options))
             parser_set_up_calls.push_back(std::move(printer));

--- a/include/sharg/detail/format_parse.hpp
+++ b/include/sharg/detail/format_parse.hpp
@@ -70,8 +70,8 @@ public:
     /*!\brief Adds an sharg::detail::get_option call to be evaluated later on.
      * \copydetails sharg::parser::add_option
      */
-    template <typename option_type, typename config_type>
-    void add_option(option_type & value, config_type const & config)
+    template <typename option_type, typename validator_t>
+    void add_option(option_type & value, config<validator_t> const & config)
     {
         option_calls.push_back(
             [this, &value, config]()
@@ -83,8 +83,8 @@ public:
     /*!\brief Adds a get_flag call to be evaluated later on.
      * \copydetails sharg::parser::add_flag
      */
-    template <typename config_type>
-    void add_flag(bool & value, config_type const & config)
+    template <typename validator_t>
+    void add_flag(bool & value, config<validator_t> const & config)
     {
         flag_calls.push_back(
             [this, &value, config]()
@@ -96,8 +96,8 @@ public:
     /*!\brief Adds a get_positional_option call to be evaluated later on.
      * \copydetails sharg::parser::add_positional_option
      */
-    template <typename option_type, typename config_type>
-    void add_positional_option(option_type & value, config_type const & config)
+    template <typename option_type, typename validator_t>
+    void add_positional_option(option_type & value, config<validator_t> const & config)
     {
         positional_option_calls.push_back(
             [this, &value, config]()
@@ -678,8 +678,8 @@ private:
      * - throws on (mis)use of both identifiers for non-container type values,
      * - re-throws the validation exception with appended option information.
      */
-    template <typename option_type, typename config_type>
-    void get_option(option_type & value, config_type const & config)
+    template <typename option_type, typename validator_t>
+    void get_option(option_type & value, config<validator_t> const & config)
     {
         bool short_id_is_set{get_option_by_id(value, config.short_id)};
         bool long_id_is_set{get_option_by_id(value, config.long_id)};

--- a/include/sharg/detail/format_tdl.hpp
+++ b/include/sharg/detail/format_tdl.hpp
@@ -125,8 +125,8 @@ public:
     /*!\brief Adds a sharg::print_list_item call to be evaluated later on.
      * \copydetails sharg::parser::add_option
      */
-    template <typename option_type, typename config_type>
-    void add_option(option_type & value, config_type const & config)
+    template <typename option_type, typename validator_t>
+    void add_option(option_type & value, config<validator_t> const & config)
     {
         auto description = config.description;
         description += (config.required ? std::string{" "} : detail::to_string(" Default: ", value, ". "));
@@ -200,8 +200,8 @@ public:
     /*!\brief Adds a sharg::print_list_item call to be evaluated later on.
      * \copydetails sharg::parser::add_flag
      */
-    template <typename config_type>
-    void add_flag(bool & value, config_type const & config)
+    template <typename validator_t>
+    void add_flag(bool & value, config<validator_t> const & config)
     {
         store_help_page_element(
             [this, config, value](std::string_view)
@@ -219,8 +219,8 @@ public:
     /*!\brief Adds a sharg::print_list_item call to be evaluated later on.
      * \copydetails sharg::parser::add_positional_option
      */
-    template <typename option_type, typename config_type>
-    void add_positional_option(option_type & value, config_type const & config)
+    template <typename option_type, typename validator_t>
+    void add_positional_option(option_type & value, config<validator_t> const & config)
     {
         std::string msg = config.validator.get_help_page_message();
 
@@ -346,7 +346,8 @@ private:
      *
      * If `spec` equals `sharg::option_spec::hidden`, the information is never added to the help page.
      */
-    void store_help_page_element(std::function<void(std::string_view)> printer, config<auto> const & config)
+    template <typename validator_t>
+    void store_help_page_element(std::function<void(std::string_view)> printer, config<validator_t> const & config)
     {
         if (config.hidden)
             return;

--- a/include/sharg/enumeration_names.hpp
+++ b/include/sharg/enumeration_names.hpp
@@ -212,7 +212,7 @@ namespace sharg
  * \experimentalapi{Experimental since version 1.0.}
  */
 // clang-format off
-// `SHARG_DOXYGEN_ONLY((size_t value))` is needed for Doxygen 1.9.5 
+// `SHARG_DOXYGEN_ONLY((size_t value))` is needed for Doxygen 1.9.5
 // Doxygen 1.9.5 bug: https://github.com/doxygen/doxygen/issues/9552
 template <typename option_type>
     requires requires { { detail::adl_only::enumeration_names_cpo<option_type>{}() }; }
@@ -245,13 +245,16 @@ concept named_enumeration = requires
 } // namespace sharg
 
 //!\cond
+namespace std
+{
+
 /*!\brief Overload of ostream operator<<
  * \details
  * \experimentalapi{Experimental since version 1.0.}
  */
 template <typename option_type>
-    requires sharg::named_enumeration<std::remove_cvref_t<option_type>>
-inline std::ostream & std::operator<<(std::ostream & s, option_type && op)
+    requires sharg::named_enumeration<remove_cvref_t<option_type>>
+inline ostream & operator<<(ostream & s, option_type && op)
 {
     for (auto & [key, value] : sharg::enumeration_names<option_type>)
     {
@@ -261,4 +264,6 @@ inline std::ostream & std::operator<<(std::ostream & s, option_type && op)
 
     return s << "<UNKNOWN_VALUE>";
 }
+
+} // namespace std
 //!\endcond

--- a/include/sharg/parser.hpp
+++ b/include/sharg/parser.hpp
@@ -938,7 +938,8 @@ private:
     }
 
     //!brief Verify the configuration given to a sharg::parser::add_option call.
-    void verify_option_config(config<auto> const & config)
+    template <typename validator_t>
+    void verify_option_config(config<validator_t> const & config)
     {
         if (sub_parser != nullptr)
             throw design_error{"You may only specify flags for the top-level parser."};
@@ -950,7 +951,8 @@ private:
     }
 
     //!brief Verify the configuration given to a sharg::parser::add_flag call.
-    void verify_flag_config(config<auto> const & config)
+    template <typename validator_t>
+    void verify_flag_config(config<validator_t> const & config)
     {
         verify_identifiers(config.short_id, config.long_id);
 
@@ -959,7 +961,8 @@ private:
     }
 
     //!brief Verify the configuration given to a sharg::parser::add_positional_option call.
-    void verify_positional_option_config(config<auto> const & config) const
+    template <typename validator_t>
+    void verify_positional_option_config(config<validator_t> const & config) const
     {
         if (config.short_id != '\0' || config.long_id != "")
             throw design_error{"Positional options are identified by their position on the command line. "


### PR DESCRIPTION
* `auto` is only allowed for non-type template parameter, e.g., `typename <size_t t>`. This is according to the Standard, gcc14 also errors: https://cdash.seqan.de/viewBuildError.php?buildid=111621
* Unified syntax `typename config_t ... config_t const & config` -> `typename validator_t ... config<validator_t> const & config`
* clang rejects the inline overloading of `std::ostream::operator<<`. Need to open the namespace.

clang still cannot deduce the template parameter for designated initialisers