### PR TITLE
[INFRA] Add external_project tests

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -1,0 +1,60 @@
+name: CMake
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types:
+      - unlabeled
+  workflow_dispatch:
+
+concurrency:
+  group: cmake-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+env:
+  SHARG_NO_VERSION_CHECK: 1
+  TZ: Europe/Berlin
+
+defaults:
+  run:
+    shell: bash -Eexuo pipefail {0}
+
+jobs:
+  build:
+    name: "External project"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'lint'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: sharg-parser
+          fetch-depth: 1
+          submodules: true
+
+      - name: Install CMake
+        uses: seqan/actions/setup-cmake@main
+        with:
+          cmake: 3.16.9
+
+      - name: Setup toolchain
+        uses: seqan/actions/setup-toolchain@main
+        with:
+          compiler: gcc-13
+          use_actions_cache: false
+
+      - name: Configure tests
+        run: |
+          mkdir sharg-build
+          cd sharg-build
+          cmake ../sharg-parser/test/external_project -DCMAKE_BUILD_TYPE=Debug
+          make -j2 sharg_test_prerequisite
+
+      - name: Build tests
+        run: |
+          cd sharg-build
+          make -k -j2
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,14 +55,23 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-22.04
     steps:
-      - name: "Cancel Coverage"
-        run: echo "Cancelling Coverage"
+      - name: "Cancel Documentation"
+        run: echo "Cancelling Documentation"
+  cancel_cmake:
+    name: Cancel running Workflows
+    concurrency:
+      group: cmake-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Cancel CMake"
+        run: echo "Cancelling CMake"
   lint:
     name: Lint
     concurrency:
       group: lint-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    needs: [cancel_linux, cancel_macos, cancel_misc, cancel_coverage, cancel_documentation]
+    needs: [cancel_linux, cancel_macos, cancel_misc, cancel_coverage, cancel_documentation, cancel_cmake]
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ The following API changes should be documented as such:
 If possible, provide tooling that performs the changes, e.g. a shell-script.
 -->
 
+# Release 1.1.1
+
+## Bug fixes
+
+* Fixed installation of Sharg via `make install` ([#202](https://github.com/seqan/sharg-parser/pull/202)).
+
+## API changes
+
+#### Compiler
+
+* Dropped support for gcc-10 ([#199](https://github.com/seqan/sharg-parser/pull/199)).
+* Added support for gcc-13 ([#199](https://github.com/seqan/sharg-parser/pull/199)).
+* Added support for clang-17 ([#197](https://github.com/seqan/sharg-parser/pull/197),
+  [#198](https://github.com/seqan/sharg-parser/pull/198)).
+
 # Release 1.1.0
 
 ## Features
@@ -25,9 +40,7 @@ If possible, provide tooling that performs the changes, e.g. a shell-script.
 * We support Gitpod. [Click here](https://gitpod.io/#https://github.com/seqan/sharg-parser/)
   to try it out.
 * **CWL support** (Common Workflow Language): An app using Sharg can now automatically export a CWL tool
-  description file via `--export-help cwl` [#94](https://github.com/seqan/sharg-parser/pull/94).
-
-## API changes
+  description file via `--export-help cwl` ([#94](https://github.com/seqan/sharg-parser/pull/94)).
 
 ## Bug fixes
 

--- a/build_system/sharg-config.cmake
+++ b/build_system/sharg-config.cmake
@@ -217,12 +217,7 @@ endif ()
 # ----------------------------------------------------------------------------
 # tool description lib (tdl) dependency
 # ----------------------------------------------------------------------------
-
-set (STORED_CMAKE_MESSAGE_LOG_LEVEL "${CMAKE_MESSAGE_LOG_LEVEL}")
-set (CMAKE_MESSAGE_LOG_LEVEL "ERROR")
 find_package (TDL QUIET HINTS ${SHARG_SUBMODULES_DIR}/submodules/tool_description_lib ${SHARG_HINT_TDL})
-set (CMAKE_MESSAGE_LOG_LEVEL "${STORED_CMAKE_MESSAGE_LOG_LEVEL}")
-unset (STORED_CMAKE_MESSAGE_LOG_LEVEL)
 
 if (TDL_FOUND)
     sharg_config_print ("Dependency:                 TDL found.")

--- a/test/external_project/CMakeLists.txt
+++ b/test/external_project/CMakeLists.txt
@@ -1,0 +1,84 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.16)
+project (sharg_test_external_project CXX)
+
+include (../sharg-test.cmake) # for SHARG_EXTERNAL_PROJECT_CMAKE_ARGS, SHARG_VERSION
+include (ExternalProject)
+
+set (SHARG_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../")
+
+include (install-sharg.cmake)
+
+option (SHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE
+        "Enable this option if you want to get a detailed list which paths were considered for find_package(...)" FALSE)
+
+# 1) This tests test/external_project/sharg_submodule_add_subdirectory/CMakeLists.txt
+#    That means we use add_subdirectory directly on sharg's top level CMakeLists.txt.
+#    This will automatically call find_package and expose our sharg::sharg target.
+#    This is expected to work with CMake >= 3.4.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+ExternalProject_Add (
+    sharg_submodule_add_subdirectory
+    PREFIX sharg_submodule_add_subdirectory
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/sharg_submodule_add_subdirectory"
+    CMAKE_ARGS ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS}
+               "-DCMAKE_FIND_DEBUG_MODE=${SHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE}" #
+               "-DSHARG_ROOT=${SHARG_ROOT}")
+
+# 2) This tests test/external_project/sharg_submodule_find_package/CMakeLists.txt
+#    We have a sharg checkout somewhere and we point CMAKE_PREFIX_PATH to <checkout>/sharg/build_system
+#    and then use `find_package` to find `sharg-config.cmake` which exposes our `sharg::sharg` target.
+#    This is expected to work with CMake >= 3.4.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+ExternalProject_Add (
+    sharg_submodule_find_package
+    PREFIX sharg_submodule_find_package
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/sharg_submodule_find_package"
+    CMAKE_ARGS ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS} "-DCMAKE_FIND_DEBUG_MODE=${SHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE}"
+               "-DCMAKE_PREFIX_PATH=${SHARG_ROOT}/build_system")
+
+# 3) This tests test/external_project/sharg_installed/CMakeLists.txt
+#    This test assumes that sharg was installed by make install (e.g. system-wide).
+#    This is the way most upstream packages, like debian, provide our library.
+#    This test assumes that `sharg-config.cmake` can be found by cmake in some global paths like /usr/share/cmake/.
+#
+#    We simulate this by using our `make package` release, e.g. the one we release under
+#    https://github.com/seqan/sharg/releases, and unzipping it to some folder and making
+#    that path globally accessible by CMAKE_SYSTEM_PREFIX_PATH.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+ExternalProject_Add (
+    sharg_installed
+    PREFIX sharg_installed
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/sharg_installed"
+    CMAKE_ARGS ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS} "-DCMAKE_FIND_DEBUG_MODE=${SHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE}"
+               "-DCMAKE_SYSTEM_PREFIX_PATH=${SHARG_SYSTEM_PREFIX}")
+add_dependencies (sharg_installed sharg_test_prerequisite)
+
+# 4) This tests test/external_project/sharg_fetch_content_zip/CMakeLists.txt
+#    It uses fetch_content (a CMake 3.14 feature) to download our zip-release (e.g. zip, tar.xz) from
+#    https://github.com/seqan/sharg/releases. fetch_content will automatically download, verify, extract it.
+#    The user only needs to define CMAKE_PREFIX_PATH to be able to find our `sharg-config.cmake`.
+#    Note that FetchContent is a CMake >= 3.14 feature.
+#    This is expected to work with CMake >= 3.14.
+# (ExternalProject_Add simulates a fresh and separate invocation of cmake ../)
+ExternalProject_Add (
+    sharg_fetch_content_zip
+    PREFIX sharg_fetch_content_zip
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/sharg_fetch_content_zip"
+    CMAKE_ARGS ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS} "-DCMAKE_FIND_DEBUG_MODE=${SHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE}"
+               "-DSHARG_PACKAGE_ZIP_URL=${SHARG_PACKAGE_ZIP_URL}")
+add_dependencies (sharg_fetch_content_zip sharg_test_prerequisite)
+
+# 5) This test is the same as 2) but emulates the settings within the setup tutorial.
+#    This test is used as snippet in the setup tutorial.
+ExternalProject_Add (
+    sharg_setup_tutorial
+    PREFIX sharg_setup_tutorial
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/sharg_setup_tutorial"
+    CMAKE_ARGS ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS} "-DCMAKE_FIND_DEBUG_MODE=${SHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE}")

--- a/test/external_project/find-package-diagnostics.cmake
+++ b/test/external_project/find-package-diagnostics.cmake
@@ -1,0 +1,48 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+# list all search places
+# NOTE: this can be enabled globally by -DSHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE=1 to help debug search paths
+# set (CMAKE_FIND_DEBUG_MODE ${SHARG_EXTERNAL_PROJECT_FIND_DEBUG_MODE})
+
+macro (sharg_print_diagnostics text)
+    message (STATUS "  ${text}")
+endmacro ()
+
+message (STATUS "=== SHARG find_package Diagnostics start ===")
+sharg_print_diagnostics ("CMAKE_COMMAND: ${CMAKE_COMMAND}")
+sharg_print_diagnostics ("CMAKE_VERSION: ${CMAKE_VERSION}")
+sharg_print_diagnostics ("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+
+sharg_print_diagnostics (
+    "Search paths (https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure)")
+sharg_print_diagnostics ("1) CMAKE_FIND_USE_PACKAGE_ROOT_PATH: ${CMAKE_FIND_USE_CMAKE_PATH}")
+sharg_print_diagnostics ("   SHARG_ROOT: ${SHARG_ROOT}")
+
+sharg_print_diagnostics ("2) CMAKE_FIND_USE_CMAKE_PATH: ${CMAKE_FIND_USE_CMAKE_PATH}")
+sharg_print_diagnostics ("   CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
+sharg_print_diagnostics ("   CMAKE_FRAMEWORK_PATH: ${CMAKE_FRAMEWORK_PATH}")
+sharg_print_diagnostics ("   CMAKE_APPBUNDLE_PATH: ${CMAKE_APPBUNDLE_PATH}")
+
+sharg_print_diagnostics ("3) CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH: ${CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH}")
+sharg_print_diagnostics ("   SHARG_DIR: ${SHARG_DIR}")
+
+# 4) Using the HINTS option.
+# See point 4 in https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure.
+# There is no output.
+
+sharg_print_diagnostics ("5) CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH: ${CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH}")
+
+sharg_print_diagnostics ("6) CMAKE_FIND_USE_PACKAGE_REGISTRY: ${CMAKE_FIND_USE_PACKAGE_REGISTRY}")
+
+sharg_print_diagnostics ("7) CMAKE_FIND_USE_CMAKE_SYSTEM_PATH: ${CMAKE_FIND_USE_CMAKE_SYSTEM_PATH}")
+sharg_print_diagnostics ("   CMAKE_SYSTEM_PREFIX_PATH: ${CMAKE_SYSTEM_PREFIX_PATH}")
+sharg_print_diagnostics ("   CMAKE_SYSTEM_FRAMEWORK_PATH: ${CMAKE_SYSTEM_FRAMEWORK_PATH}")
+sharg_print_diagnostics ("   CMAKE_SYSTEM_APPBUNDLE_PATH: ${CMAKE_SYSTEM_APPBUNDLE_PATH}")
+
+sharg_print_diagnostics ("8) CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY: ${CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY}")
+message (STATUS "=== SHARG find_package Diagnostics end ===")

--- a/test/external_project/install-sharg.cmake
+++ b/test/external_project/install-sharg.cmake
@@ -1,0 +1,30 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.14)
+
+# install and package sharg library
+ExternalProject_Add (
+    sharg_test_prerequisite
+    PREFIX sharg_test_prerequisite
+    SOURCE_DIR "${SHARG_ROOT}"
+    CMAKE_ARGS ${SHARG_EXTERNAL_PROJECT_CMAKE_ARGS} #
+               "-DCMAKE_INSTALL_PREFIX=<BINARY_DIR>/usr"
+    STEP_TARGETS configure install
+    BUILD_BYPRODUCTS "<BINARY_DIR>/include")
+
+set (SHARG_PACKAGE_ZIP_URL "${PROJECT_BINARY_DIR}/sharg-${SHARG_VERSION}-${CMAKE_SYSTEM_NAME}.zip")
+ExternalProject_Add_Step (
+    sharg_test_prerequisite package
+    COMMAND ${CMAKE_CPACK_COMMAND} -G ZIP -B "${PROJECT_BINARY_DIR}"
+    DEPENDEES configure install
+    WORKING_DIRECTORY "<BINARY_DIR>"
+    BYPRODUCTS ${SHARG_PACKAGE_ZIP_URL} #
+               "${SHARG_PACKAGE_ZIP_URL}.sha256")
+
+ExternalProject_Get_Property (sharg_test_prerequisite BINARY_DIR)
+set (SHARG_SYSTEM_PREFIX "${BINARY_DIR}/usr")

--- a/test/external_project/sharg_fetch_content_zip/CMakeLists.txt
+++ b/test/external_project/sharg_fetch_content_zip/CMakeLists.txt
@@ -1,0 +1,36 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.14)
+project (sharg_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+file (SHA256 "${SHARG_PACKAGE_ZIP_URL}" SHARG_PACKAGE_ZIP_HASH)
+message (STATUS "SHARG_PACKAGE_ZIP_URL: ${SHARG_PACKAGE_ZIP_URL}")
+message (STATUS "SHARG_PACKAGE_ZIP_HASH: SHA256=${SHARG_PACKAGE_ZIP_HASH}")
+# ---
+
+# fetch sharg sources (requires >= cmake 3.14)
+include (FetchContent)
+FetchContent_Declare (
+    sharg
+    URL "${SHARG_PACKAGE_ZIP_URL}" # change these values
+    URL_HASH "SHA256=${SHARG_PACKAGE_ZIP_HASH}" # change these values
+)
+FetchContent_MakeAvailable (sharg)
+
+# add sharg to search path
+list (APPEND CMAKE_PREFIX_PATH "${sharg_SOURCE_DIR}")
+
+# require sharg with a version between >=1.0.0 and <2.0.0
+find_package (sharg 1.0 REQUIRED)
+
+# build app with sharg
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world sharg::sharg)
+install (TARGETS hello_world)

--- a/test/external_project/sharg_installed/CMakeLists.txt
+++ b/test/external_project/sharg_installed/CMakeLists.txt
@@ -1,0 +1,25 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.4)
+project (sharg_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+# ---
+
+# require sharg with a version between >=1.0.0 and <2.0.0
+find_package (sharg 1.0 REQUIRED)
+
+# build app with sharg
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world sharg::sharg)
+if (CMAKE_VERSION VERSION_LESS 3.14)
+    install (TARGETS hello_world RUNTIME DESTINATION bin)
+else ()
+    install (TARGETS hello_world) # RUNTIME DESTINATION not needed anymore since cmake 3.14
+endif ()

--- a/test/external_project/sharg_setup_tutorial/CMakeLists.txt
+++ b/test/external_project/sharg_setup_tutorial/CMakeLists.txt
@@ -1,0 +1,37 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+# ---
+
+# Copy the cpp so we can use add_executable like in the tutorial
+file (COPY "${CMAKE_SOURCE_DIR}/../src/hello_world.cpp" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+file (RENAME "${CMAKE_CURRENT_BINARY_DIR}/hello_world.cpp" "${CMAKE_CURRENT_BINARY_DIR}/another_program.cpp")
+file (COPY "${CMAKE_SOURCE_DIR}/../src/hello_world.cpp" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+# In the tutorial, the CMAKE_CURRENT_SOURCE_DIR is a sibling directory of the sharg checkout
+set (CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../../source")
+
+## [adding_files]
+cmake_minimum_required (VERSION 3.4)
+project (sharg_tutorial CXX)
+
+# add sharg to search path
+list (APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../sharg-parser/build_system")
+
+# require sharg with a version between >=1.0.0 and <2.0.0
+find_package (sharg 1.0 REQUIRED)
+
+# build app with sharg
+add_executable (hello_world hello_world.cpp)
+target_link_libraries (hello_world sharg::sharg)
+
+add_executable (another_program another_program.cpp)
+target_link_libraries (another_program sharg::sharg)
+## [adding_files]
+
+install (TARGETS hello_world another_program)

--- a/test/external_project/sharg_submodule_add_subdirectory/CMakeLists.txt
+++ b/test/external_project/sharg_submodule_add_subdirectory/CMakeLists.txt
@@ -1,0 +1,22 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.4)
+project (sharg_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+# ---
+
+# use git checkout of sharg
+option (INSTALL_SHARG "" OFF) # we don't need to install sharg
+add_subdirectory ("${SHARG_ROOT}" "sharg_build")
+
+# build app with sharg
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world sharg::sharg)
+install (TARGETS hello_world)

--- a/test/external_project/sharg_submodule_find_package/CMakeLists.txt
+++ b/test/external_project/sharg_submodule_find_package/CMakeLists.txt
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------------------------------------
+# Copyright (c) 2006-2023, Knut Reinert & Freie Universität Berlin
+# Copyright (c) 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+# shipped with this file and also available at: https://github.com/seqan/sharg-parser/blob/main/LICENSE.md
+# --------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required (VERSION 3.4)
+project (sharg_app CXX)
+
+# --- helper scripts
+include (../find-package-diagnostics.cmake)
+# ---
+
+# add sharg to search path
+list (APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/submodules/sharg/build_system") # change this value
+
+# require sharg with a version between >=1.0.0 and <2.0.0
+find_package (sharg 1.0 REQUIRED)
+
+# build app with sharg
+add_executable (hello_world ../src/hello_world.cpp)
+target_link_libraries (hello_world sharg::sharg)
+install (TARGETS hello_world)

--- a/test/external_project/src/hello_world.cpp
+++ b/test/external_project/src/hello_world.cpp
@@ -1,0 +1,13 @@
+#include <sharg/all.hpp>
+
+int main(int argc, char ** argv)
+{
+    int val{};
+
+    sharg::parser parser{"Eat-Me-App", argc, argv};
+    parser.add_subsection("Eating Numbers");
+    parser.add_option(val, sharg::config{.short_id = 'i', .long_id = "int", .description = "Desc."});
+    parser.parse();
+
+    return 0;
+}


### PR DESCRIPTION
Adapted from SeqAn3. Sharg 1.1.0 install is broken, because tdl/yaml-cpp is not installed correctly. As a first step, this adds tests to catch these errors.