### PR TITLE
[MISC] Defer everything to parse()

### DIFF
--- a/include/sharg/detail/format_base.hpp
+++ b/include/sharg/detail/format_base.hpp
@@ -386,7 +386,7 @@ public:
             derived_t().print_line("See the respective help page for further details (e.g. by calling " + meta.app_name
                                        + " " + command_names[0] + " -h).",
                                    true);
-            derived_t().print_line("The following options below belong to the top-level parser and need to be "
+            derived_t().print_line("The following options belong to the top-level parser and need to be "
                                    "specified \\fBbefore\\fP the subcommand key word. Every argument after the "
                                    "subcommand key word is passed on to the corresponding sub-parser.",
                                    true);

--- a/test/unit/detail/format_help_test.cpp
+++ b/test/unit/detail/format_help_test.cpp
@@ -539,11 +539,11 @@ TEST_F(format_help_test, copyright)
 
 TEST_F(format_help_test, subcommand_parser)
 {
-    int option_value{};
+    bool flag_value{false};
 
     auto parser = get_subcommand_parser({"-h"}, {"sub1", "sub2"});
     parser.info.description.push_back("description");
-    parser.add_option(option_value, sharg::config{.short_id = 'f', .long_id = "foo", .description = "foo bar."});
+    parser.add_flag(flag_value, sharg::config{.short_id = 'f', .long_id = "foo", .description = "A flag."});
 
     std::string expected = "test_parser\n"
                            "===========\n"
@@ -558,12 +558,13 @@ TEST_F(format_help_test, subcommand_parser)
                            "    See the respective help page for further details (e.g. by calling\n"
                            "    test_parser sub1 -h).\n"
                            "\n"
-                           "    The following options below belong to the top-level parser and need to be\n"
+                           "    The following options belong to the top-level parser and need to be\n"
                            "    specified before the subcommand key word. Every argument after the\n"
                            "    subcommand key word is passed on to the corresponding sub-parser.\n"
-                           "\nOPTIONS\n"
-                           "    -f, --foo (signed 32 bit integer)\n"
-                           "          foo bar. Default: 0\n"
+                           "\n"
+                           "OPTIONS\n"
+                           "    -f, --foo\n"
+                           "          A flag.\n"
                            "\n"
                          + basic_options_str + "\n" + basic_version_str;
     EXPECT_EQ(get_parse_cout_on_exit(parser), expected);

--- a/test/unit/detail/format_html_test.cpp
+++ b/test/unit/detail/format_html_test.cpp
@@ -203,20 +203,19 @@ TEST_F(format_html_test, full_information_information)
 
 TEST_F(format_html_test, parse_error)
 {
-    std::vector<std::string> argv1{"./help_add_test", "--version-check", "false", "--export-help"};
-    std::vector<std::string> argv2{"./help_add_test", "--version-check", "false", "--export-help=atml"};
-    std::vector<std::string> argv3{"./help_add_test", "--version-check", "false", "--export-help", "atml"};
-    std::vector<std::string> argv4{"./help_add_test", "--version-check", "false", "--export-help#html"};
-
     // no value after --export-help
-    EXPECT_THROW((sharg::parser{"test_parser", argv1}), sharg::parser_error);
+    auto parser = get_parser("./help_add_test", "--export-help");
+    EXPECT_THROW(parser.parse(), sharg::parser_error);
+
+    // wrong value after --export-help=
+    parser = get_parser("./help_add_test", "--export-help=atml");
+    EXPECT_THROW(parser.parse(), sharg::validation_error);
 
     // wrong value after --export-help
-    EXPECT_THROW((sharg::parser{"test_parser", argv2}), sharg::validation_error);
-
-    // wrong value after --export-help
-    EXPECT_THROW((sharg::parser{"test_parser", argv3}), sharg::validation_error);
+    parser = get_parser("./help_add_test", "--export-help", "atml");
+    EXPECT_THROW(parser.parse(), sharg::validation_error);
 
     // Currently not checking for `=`
-    EXPECT_NO_THROW((sharg::parser{"test_parser", argv4}));
+    parser = get_parser("./help_add_test", "--export-help#html");
+    EXPECT_NE(get_parse_cout_on_exit(parser), "");
 }

--- a/test/unit/detail/format_html_test.cpp
+++ b/test/unit/detail/format_html_test.cpp
@@ -215,7 +215,7 @@ TEST_F(format_html_test, parse_error)
     parser = get_parser("./help_add_test", "--export-help", "atml");
     EXPECT_THROW(parser.parse(), sharg::validation_error);
 
-    // Currently not checking for `=`
+    // wrong separator
     parser = get_parser("./help_add_test", "--export-help#html");
-    EXPECT_NE(get_parse_cout_on_exit(parser), "");
+    EXPECT_THROW(parser.parse(), sharg::unknown_option);
 }

--- a/test/unit/parser/format_parse_test.cpp
+++ b/test/unit/parser/format_parse_test.cpp
@@ -623,12 +623,12 @@ TEST_F(format_parse_test, multiple_empty_options)
 TEST_F(format_parse_test, version_check_option_error)
 {
     // version-check must be followed by a value
-    std::vector<std::string> arguments{"./parser_test", "--version-check"};
-    EXPECT_THROW((sharg::parser{"test_parser", arguments, sharg::update_notifications::off}), sharg::parser_error);
+    auto parser = get_parser("--version-check");
+    EXPECT_THROW(parser.parse(), sharg::parser_error);
 
     // version-check value must be 0 or 1
-    arguments.push_back("foo");
-    EXPECT_THROW((sharg::parser{"test_parser", arguments, sharg::update_notifications::off}), sharg::parser_error);
+    parser = get_parser("--version-check", "foo");
+    EXPECT_THROW(parser.parse(), sharg::parser_error);
 }
 
 TEST_F(format_parse_test, subcommand_parser_success)

--- a/test/unit/parser/format_parse_test.cpp
+++ b/test/unit/parser/format_parse_test.cpp
@@ -681,16 +681,16 @@ TEST_F(format_parse_test, subcommand_parser_success)
 TEST_F(format_parse_test, subcommand_parser_error)
 {
     // incorrect sub command regardless of following arguments, https://github.com/seqan/seqan3/issues/2172
-    auto top_level_parser = get_subcommand_parser({"subiddysub", "-f"}, {"sub1"});
-    EXPECT_THROW(top_level_parser.parse(), sharg::parser_error);
+    auto parser = get_subcommand_parser({"subiddysub", "-f"}, {"sub1"});
+    EXPECT_THROW(parser.parse(), sharg::parser_error);
 
     // incorrect sub command with no other arguments
-    top_level_parser = get_subcommand_parser({"subiddysub"}, {"sub1"});
-    EXPECT_THROW(top_level_parser.parse(), sharg::parser_error);
+    parser = get_subcommand_parser({"subiddysub"}, {"sub1"});
+    EXPECT_THROW(parser.parse(), sharg::parser_error);
 
     // incorrect sub command with trailing special option, https://github.com/seqan/sharg-parser/issues/171
-    top_level_parser = get_subcommand_parser({"subiddysub", "-h"}, {"sub1"});
-    EXPECT_THROW(top_level_parser.parse(), sharg::parser_error);
+    parser = get_subcommand_parser({"subiddysub", "-h"}, {"sub1"});
+    EXPECT_THROW(parser.parse(), sharg::parser_error);
 }
 
 TEST_F(format_parse_test, issue1544)

--- a/test/unit/parser/parser_design_error_test.cpp
+++ b/test/unit/parser/parser_design_error_test.cpp
@@ -263,16 +263,18 @@ TEST_F(design_error_test, subcommand_parser_error)
     EXPECT_THROW(parser.parse(), sharg::design_error);
 
     // no positional options are allowed
-    parser = get_subcommand_parser({"foo"}, {"foo"});
+    parser = get_subcommand_parser({"-f", "foo"}, {"foo"});
 
     EXPECT_THROW(parser.add_positional_option(flag_value, sharg::config{}), sharg::design_error);
     EXPECT_THROW(parser.add_option(flag_value, sharg::config{.short_id = 'o'}), sharg::design_error);
     EXPECT_NO_THROW(parser.add_flag(flag_value, sharg::config{.short_id = 'f'}));
-    EXPECT_EQ(flag_value, false);
-
     EXPECT_THROW(parser.get_sub_parser(), sharg::design_error);
+    EXPECT_EQ(flag_value, false);
     EXPECT_NO_THROW(parser.parse()); // Prints nothing, but sets sub_parser.
     EXPECT_NO_THROW(parser.get_sub_parser());
+    EXPECT_EQ(flag_value, true);
+
+    flag_value = false;
 
     // no options are allowed
     parser = get_subcommand_parser({"-o", "true"}, {"foo"});
@@ -282,7 +284,6 @@ TEST_F(design_error_test, subcommand_parser_error)
     EXPECT_EQ(flag_value, false);
     EXPECT_THROW(parser.parse(), sharg::too_few_arguments);
     EXPECT_EQ(flag_value, false);
-    EXPECT_THROW(parser.parse(), sharg::user_input_error); // Todo: Subcommand is required?
 }
 
 TEST_F(design_error_test, not_allowed_after_parse)

--- a/test/unit/parser/parser_design_error_test.cpp
+++ b/test/unit/parser/parser_design_error_test.cpp
@@ -252,22 +252,37 @@ TEST_F(design_error_test, subcommand_parser_error)
     parser.add_flag(flag_value, sharg::config{.short_id = 'f'});
 
     EXPECT_NO_THROW(parser.parse());
-    EXPECT_EQ(true, flag_value);
+    EXPECT_EQ(flag_value, true);
     EXPECT_THROW(parser.get_sub_parser(), sharg::design_error);
 
+    flag_value = false;
+
     // subcommand key word must only contain alpha numeric characters
-    EXPECT_THROW((sharg::parser{"top_level", {"./test_parser"}, sharg::update_notifications::off, {"with space"}}),
-                 sharg::design_error);
+    parser = get_subcommand_parser({}, {"with space"});
 
-    // no positional/options are allowed
+    EXPECT_THROW(parser.parse(), sharg::design_error);
+
+    // no positional options are allowed
     parser = get_subcommand_parser({"foo"}, {"foo"});
-    EXPECT_THROW((parser.add_option(flag_value, sharg::config{.short_id = 'f'})), sharg::design_error);
-    EXPECT_THROW((parser.add_positional_option(flag_value, sharg::config{})), sharg::design_error);
 
-    // Todo: Allowed
-    parser = get_subcommand_parser({""}, {"foo"});
-    EXPECT_NO_THROW((parser.add_option(flag_value, sharg::config{.short_id = 'f'})));
-    EXPECT_NO_THROW((parser.add_positional_option(flag_value, sharg::config{})));
+    EXPECT_THROW(parser.add_positional_option(flag_value, sharg::config{}), sharg::design_error);
+    EXPECT_THROW(parser.add_option(flag_value, sharg::config{.short_id = 'o'}), sharg::design_error);
+    EXPECT_NO_THROW(parser.add_flag(flag_value, sharg::config{.short_id = 'f'}));
+    EXPECT_EQ(flag_value, false);
+
+    EXPECT_THROW(parser.get_sub_parser(), sharg::design_error);
+    EXPECT_NO_THROW(parser.parse()); // Prints nothing, but sets sub_parser.
+    EXPECT_NO_THROW(parser.get_sub_parser());
+
+    // no options are allowed
+    parser = get_subcommand_parser({"-o", "true"}, {"foo"});
+
+    EXPECT_THROW(parser.add_positional_option(flag_value, sharg::config{}), sharg::design_error);
+    EXPECT_THROW(parser.add_option(flag_value, sharg::config{.short_id = 'o'}), sharg::design_error);
+    EXPECT_EQ(flag_value, false);
+    EXPECT_THROW(parser.parse(), sharg::too_few_arguments);
+    EXPECT_EQ(flag_value, false);
+    EXPECT_THROW(parser.parse(), sharg::user_input_error); // Todo: Subcommand is required?
 }
 
 TEST_F(design_error_test, not_allowed_after_parse)


### PR DESCRIPTION
* Defers everything to `parse()`
* Refactors `parse()`
* Refactors `init()`
* No options/positional options allowed for subcommands (Follow-up)
* Fixes `--export-helpXhtml` being accepted for any `X`
---

Follow-up:

* [x] **Question**: **YES**: Are options and flags allowed for the top-level-parser when there are subcommands?
* [x] **Question**: **NO**: Must there always be a subcommand?
  ```cpp
    sharg::parser parser{"./test_parser", {"-o", "true"}, /* update off */, {"foo"}};
    parser.add_option(flag_value, sharg::config{.short_id = 'o'};
    parser.parse(); // Throws because no special format + there are subcommands -> subcommand is required.
   ```
   It's currently a `sharg::user_input_error` (`verify_subcommand()`).
   I don't think it's necessary. It might be hard to differentiate between options/flags for the top-level-parser and a potentially misspelled subcommand.
* [x] Add misspelled subcommand check back. Potentially via catching too_many_arguments from format_parse.
* [ ] subcommand is option value, e.g., `./app -o foo`, where `foo` is a subcommand and `-o` is either a flag or an option
* [x] **Question**: ~~Commit 3~~Deferred: Do we want something like a `std::monostate` for the format variant?¹ To get rid of the `special_format_was_set`, I could also just use any non-special-format as default for the variant. But `format_empty` might be more expressive and help to detect errors.

¹ Can't use `std::monostate` directly because the `visit` call needs to be valid for all possible variants.