### PR TITLE
[FIX] Do not find_package yourself

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project (sharg
          DESCRIPTION "Sharg -- hungrily eating away your arguments"
          HOMEPAGE_URL "https://github.com/seqan/sharg-parser")
 
-find_package (Sharg 1.0 REQUIRED HINTS ${SHARG_MODULE_PATH})
+include (sharg-config)
 
 option (INSTALL_SHARG "Enable installation of Sharg. (Projects embedding Sharg may want to turn this OFF.)" ON)
 

--- a/cmake/sharg-config.cmake
+++ b/cmake/sharg-config.cmake
@@ -288,30 +288,33 @@ endif ()
 # Finish find_package call
 # ----------------------------------------------------------------------------
 
-find_package_handle_standard_args (${CMAKE_FIND_PACKAGE_NAME} REQUIRED_VARS SHARG_INCLUDE_DIR)
+if (CMAKE_FIND_PACKAGE_NAME)
+    find_package_handle_standard_args (${CMAKE_FIND_PACKAGE_NAME} REQUIRED_VARS SHARG_INCLUDE_DIR)
 
-# Set SHARG_* variables with the content of ${CMAKE_FIND_PACKAGE_NAME}_(FOUND|...|VERSION)
-# This needs to be done, because `find_package(SHARG)` might be called in any case-sensitive way and we want to
-# guarantee that SHARG_* are always set.
-foreach (package_var
-         FOUND
-         DIR
-         ROOT
-         CONFIG
-         VERSION
-         VERSION_MAJOR
-         VERSION_MINOR
-         VERSION_PATCH
-         VERSION_TWEAK
-         VERSION_COUNT)
-    set (SHARG_${package_var} "${${CMAKE_FIND_PACKAGE_NAME}_${package_var}}")
-endforeach ()
-
+    # Set SHARG_* variables with the content of ${CMAKE_FIND_PACKAGE_NAME}_(FOUND|...|VERSION)
+    # This needs to be done, because `find_package(SHARG)` might be called in any case-sensitive way and we want to
+    # guarantee that SHARG_* are always set.
+    foreach (package_var
+             FOUND
+             DIR
+             ROOT
+             CONFIG
+             VERSION
+             VERSION_MAJOR
+             VERSION_MINOR
+             VERSION_PATCH
+             VERSION_TWEAK
+             VERSION_COUNT)
+        set (SHARG_${package_var} "${${CMAKE_FIND_PACKAGE_NAME}_${package_var}}")
+    endforeach ()
+else ()
+    set (SHARG_VERSION "${PACKAGE_VERSION}")
+endif ()
 # ----------------------------------------------------------------------------
 # Export targets
 # ----------------------------------------------------------------------------
 
-if (SHARG_FOUND AND NOT TARGET sharg::sharg)
+if (NOT TARGET sharg::sharg)
     add_library (sharg_sharg INTERFACE)
     target_compile_definitions (sharg_sharg INTERFACE ${SHARG_DEFINITIONS})
     target_compile_options (sharg_sharg INTERFACE ${SHARG_CXX_FLAGS})


### PR DESCRIPTION
CPM usually does a find_package redirect.
If `find_package` is called for some package added via CPM, it is redirected to CPM.

Before CPM 0.40.6, there was a bug that prevented this redirection from working properly.

If sharg is added via CPM, CPM will call sharg 's `CMakeLists.txt`.
Because we use `find_package` there, it is redirected and results in sharg not being available.