### PR TITLE
[FIX] gcc15: Workaround bogus warning

### DIFF
--- a/include/sharg/detail/format_tdl.hpp
+++ b/include/sharg/detail/format_tdl.hpp
@@ -232,9 +232,10 @@ public:
                     parameters.push_back(tdl::Node{
                         .name = config.long_id,
                         .description = description,
-                        .tags = std::move(tags),
                         .value = to_tdl(value),
                     });
+                    // gcc 15 with hardened flags (fedora-flags) doesn't like having the move in the tdl::Node ctor.
+                    parameters.back().tags = std::move(tags);
                     info.cliMapping.emplace_back("--" + config.long_id, config.long_id);
                 },
                 config);


### PR DESCRIPTION
https://gist.github.com/eseiler/c1115cc70b5847c05043ef1a9da8cfb0